### PR TITLE
Delicious html import

### DIFF
--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -546,7 +546,12 @@ class Bookmarks {
 				}
 			}
 
-			self::addBookmark($user, $db, $ref, $title, $tags, $desc_str);
+			$private = FALSE;
+			if ($link->hasAttribute("private") && $link->getAttribute("private") === "1") {
+				$private = TRUE;
+			}
+
+			self::addBookmark($user, $db, $ref, $title, $tags, $desc_str, $private);
 		}
 
 		return array();

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -462,7 +462,7 @@ class Bookmarks {
 			$query = $db->prepareQuery("
 			INSERT INTO `*PREFIX*bookmarks`
 			(`url`, `title`, `user_id`, `public`, `added`, `lastmodified`, `description`)
-			VALUES (?, ?, ?, ?, $added, $added, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
 			");
 
 			$params = array(
@@ -470,6 +470,8 @@ class Bookmarks {
 				htmlspecialchars_decode($title),
 				$userid,
 				$public,
+				$added,
+				$added,
 				$description,
 			);
 			$query->execute($params);

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -426,7 +426,7 @@ class Bookmarks {
 	 * @param boolean $public True if the bookmark is publishable to not registered users
 	 * @return int The id of the bookmark created
 	 */
-	public static function addBookmark($userid, IDb $db, $url, $title, $tags = array(), $description = '', $is_public = false) {
+	public static function addBookmark($userid, IDb $db, $url, $title, $tags = array(), $description = '', $is_public = false, $added = 0) {
 		$public = $is_public ? 1 : 0;
 		$url_without_prefix = substr($url, strpos($url, "://") + 3); // Removes everything from the url before the "://" pattern (included)
 		$enc_url_noprefix = htmlspecialchars_decode($url_without_prefix);
@@ -456,10 +456,13 @@ class Bookmarks {
 			$query->execute($params);
 			return $row['id'];
 		} else {
+			if ($added <= 0) {
+				$added = "UNIX_TIMESTAMP()";
+			}
 			$query = $db->prepareQuery("
 			INSERT INTO `*PREFIX*bookmarks`
 			(`url`, `title`, `user_id`, `public`, `added`, `lastmodified`, `description`)
-			VALUES (?, ?, ?, ?, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), ?)
+			VALUES (?, ?, ?, ?, $added, $added, ?)
 			");
 
 			$params = array(
@@ -551,7 +554,12 @@ class Bookmarks {
 				$private = TRUE;
 			}
 
-			self::addBookmark($user, $db, $ref, $title, $tags, $desc_str, $private);
+			$added = 0;
+			if ($link->hasAttribute("add_date")) {
+				$added = $link->getAttribute("add_date");
+			}
+
+			self::addBookmark($user, $db, $ref, $title, $tags, $desc_str, $private, $added);
 		}
 
 		return array();

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -457,23 +457,36 @@ class Bookmarks {
 			return $row['id'];
 		} else {
 			if ($added <= 0) {
-				$added = "UNIX_TIMESTAMP()";
-			}
-			$query = $db->prepareQuery("
-			INSERT INTO `*PREFIX*bookmarks`
-			(`url`, `title`, `user_id`, `public`, `added`, `lastmodified`, `description`)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
-			");
+				$query = $db->prepareQuery("
+				INSERT INTO `*PREFIX*bookmarks`
+				(`url`, `title`, `user_id`, `public`, `added`, `lastmodified`, `description`)
+				VALUES (?, ?, ?, ?, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), ?)
+				");
 
-			$params = array(
-				$enc_url,
-				htmlspecialchars_decode($title),
-				$userid,
-				$public,
-				$added,
-				$added,
-				$description,
-			);
+				$params = array(
+					$enc_url,
+					htmlspecialchars_decode($title),
+					$userid,
+					$public,
+					$description,
+				);
+			} else {
+				$query = $db->prepareQuery("
+				INSERT INTO `*PREFIX*bookmarks`
+				(`url`, `title`, `user_id`, `public`, `added`, `lastmodified`, `description`)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				");
+
+				$params = array(
+					$enc_url,
+					htmlspecialchars_decode($title),
+					$userid,
+					$public,
+					$added,
+					$added,
+					$description,
+				);
+			}
 			$query->execute($params);
 
 			$b_id = $db->getInsertId('*PREFIX*bookmarks');

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -532,8 +532,19 @@ class Bookmarks {
 			$tags = explode(',', $tag_str);
 
 			$desc_str = '';
-			if ($link->hasAttribute("description"))
+			if ($link->hasAttribute("description")) {
 				$desc_str = $link->getAttribute("description");
+			} else {
+				/* Get description from a following <DD> when link in a
+				 * <DT> (e.g., Delicious export) */
+				$parent = $link->parentNode;
+				if ($parent && $parent->tagName == "dt") {
+					$dd = $parent->nextSibling;
+					if ($dd->tagName == "dd") {
+						$desc_str = trim($dd->nodeValue);
+					}
+				}
+			}
 
 			self::addBookmark($user, $db, $ref, $title, $tags, $desc_str);
 		}

--- a/controller/webviewcontroller.php
+++ b/controller/webviewcontroller.php
@@ -12,6 +12,7 @@
 
 namespace OCA\Bookmarks\Controller;
 
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use \OCP\IRequest;
 use \OCP\AppFramework\Http\TemplateResponse;
 use \OCP\AppFramework\Controller;
@@ -38,7 +39,13 @@ class WebViewController extends Controller {
 	public function index() {
 		$bookmarkleturl = $this->urlgenerator->getAbsoluteURL('index.php/apps/bookmarks/bookmarklet');
 		$params = array('user' => $this->userId, 'bookmarkleturl' => $bookmarkleturl);
-		return new TemplateResponse('bookmarks', 'main', $params);
+
+		$policy = new ContentSecurityPolicy();
+		$policy->addAllowedFrameDomain("'self'");
+
+		$response = new TemplateResponse('bookmarks', 'main', $params);
+		$response->setContentSecurityPolicy($policy);
+		return $response;
 	}
 
 	/**

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -21,6 +21,16 @@ class Test_LibBookmarks_Bookmarks extends PHPUnit_Framework_TestCase {
 		$this->assertCount(1, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
 	}
 
+	function testAddBookmarkWithDate() {
+		$added = 1143823532;
+		$this->cleanDB();
+		$this->assertCount(0, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
+		$id = Bookmarks::addBookmark($this->userid, $this->db, 'http://owncloud.org', 'Owncloud project', array('oc', 'cloud'), 'An Awesome project', $added);
+		$this->assertCount(1, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
+		$bookmark = Bookmarks::findUniqueBookmark($id, $this->userid, $this->db);
+		$this->assertEquals($added, $bookmark['added']);
+	}
+
 	function testFindBookmarks() {
 		$this->cleanDB();
 		Bookmarks::addBookmark($this->userid, $this->db, "http://www.google.de", "Google", array("one"), "PrivateNoTag", false);

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -25,7 +25,7 @@ class Test_LibBookmarks_Bookmarks extends PHPUnit_Framework_TestCase {
 		$added = 1143823532;
 		$this->cleanDB();
 		$this->assertCount(0, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
-		$id = Bookmarks::addBookmark($this->userid, $this->db, 'http://owncloud.org', 'Owncloud project', array('oc', 'cloud'), 'An Awesome project', $added);
+		$id = Bookmarks::addBookmark($this->userid, $this->db, 'http://owncloud.org', 'Owncloud project', array('oc', 'cloud'), 'An Awesome project', true, $added);
 		$this->assertCount(1, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
 		$bookmark = Bookmarks::findUniqueBookmark($id, $this->userid, $this->db);
 		$this->assertEquals($added, $bookmark['added']);


### PR DESCRIPTION
Import bookmarks' description, private bit, and creation date from Delicious HTML exports. Note, this is NOT the same feature as #120, which mainly focuses on importing XML exports.

This branch is based on and includes the fix for #180 (#182).

fixes: #181
