### PR TITLE
Replace ownCloud with Nextcloud in appinfo

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,17 +2,14 @@
 <info>
 	<id>bookmarks</id>
 	<name>Bookmarks</name>
-	<description>Bookmark manager for ownCloud</description>
+	<description>Bookmark manager for Nextcloud and ownCloud</description>
 	<licence>AGPL</licence>
 	<author>Arthur Schiwon, Marvin Thomas Rabe, Stefan Klemm</author>
 	<version>0.9.0</version>
-	<documentation>
-            <user>https://doc.owncloud.org/server/9.0/user_manual/bookmarks.html</user>
-        </documentation>
 	<category>productivity</category>
-	<website>https://github.com/owncloud/bookmarks</website>
-	<bugs>https://github.com/owncloud/bookmarks/issues</bugs>
-	<repository type="git">https://github.com/owncloud/bookmarks.git</repository>
+	<website>https://github.com/nextcloud/bookmarks</website>
+	<bugs>https://github.com/nextcloud/bookmarks/issues</bugs>
+	<repository type="git">https://github.com/nextcloud/bookmarks.git</repository>
 	<dependencies>
 		<owncloud min-version="9.0" max-version="9.2" />
 		<nextcloud min-version="9" max-version="11" />


### PR DESCRIPTION
..and remove link to obsolete documentation.

Was removed from Nextcloud Docs in nextcloud/documentation#120