### PR TITLE
disable cert check when first attempt to fetch meta data failed

### DIFF
--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -586,7 +586,10 @@ class Bookmarks {
 			$options = [];
 			if($tryHarder) {
 				$curlOptions = [ 'curl' =>
-					[ CURLOPT_HTTPHEADER => ['Expect:'] ]
+					[
+						CURLOPT_HTTPHEADER     => ['Expect:'],
+						CURLOPT_SSL_VERIFYPEER => 0
+					]
 				];
 				if(version_compare(ClientInterface::VERSION, '6') === -1) {
 					$options = ['config' => $curlOptions];


### PR DESCRIPTION
fixes #301 

I don't like turning cert checks off, however you won't bookmark a site if you cannot access this. Could this be possibly misused to get you some bad content, e.g. you receive a different site from your browser than the server does? But what would be the benefit? 