### PR TITLE
Add rel="nofollow noopener"

### DIFF
--- a/templates/js_tpl.php
+++ b/templates/js_tpl.php
@@ -7,7 +7,7 @@
             </span>&nbsp;
         </p>
         <p class="bookmark_title">
-            <a href="<&= checkURL(encodeURI(url)) &>" target="_blank" class="bookmark_link" rel="noreferrer">
+            <a href="<&= checkURL(encodeURI(url)) &>" target="_blank" class="bookmark_link" rel="nofollow noopener noreferrer">
                 <&= escapeHTML(title == '' ? encodeURI(url) : title ) &>
             </a>
             <span class="bookmark_edit bookmark_edit_btn">


### PR DESCRIPTION
The page we're linking to gains partial access to the linking page via the window.opener object.
For more info see this: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/