### PR TITLE
prepare 0.10.0 release, bump version, remove owncloud tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
     - DB=pgsql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable10
     - DB=pgsql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable11
     - DB=sqlite SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable9
-    - DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=master
-    - DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=stable9.1
 
 matrix:
   exclude:
@@ -36,10 +34,6 @@ matrix:
     env: DB=pgsql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable10
   - php: 5.6
     env: DB=pgsql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable11
-  - php: 5.6
-    env: DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=master
-  - php: 5.6
-    env: DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=stable9.1
   - php: 7.1
     env: DB=sqlite SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable9
   - php: 7.1
@@ -48,11 +42,6 @@ matrix:
     env: DB=mysql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable10
   - php: 7.1
     env: DB=pgsql SERVER=nextcloud/travis_ci/master SERVER_BRANCH=stable10
-  - php: 7.1
-    env: DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=stable9.1
-  allow_failures:
-    - php: 7
-      env: DB=sqlite SERVER=owncloud/administration/master/travis-ci SERVER_BRANCH=stable9.1
   fast_finish: true
 
 branches:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rewrite by [Stefan Klemm] aka ganomi (https://github.com/ganomi)
 * Dependency Injection for user and db is used througout the controllers
 * The Routing features a consistent rest api
 * The Routing provides some legacy routes, so that for exampe the Android Bookmarks App still works.
-* Merged all the changes from https://github.com/owncloud/bookmarks/pull/68 and added visual fixes. App uses the App Framework Styling on the Client side now.
+* Merged all the changes from https://github.com/nextcloud/bookmarks/pull/68 and added visual fixes. App uses the App Framework Styling on the Client side now.
 
 There is a publicly available api that provides access to bookmarks per user. (This is usefull in connection with the Wordpress Plugin https://github.com/mario-nolte/oc2wp-bookmarks)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,11 +3,12 @@
 	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>bookmarks</id>
 	<name>Bookmarks</name>
-	<summary>A Bookmark manager for Nextcloud and ownCloud</summary>
-	<description><![CDATA[Bookmark manager for Nextcloud and ownCloud]]></description>
-	<version>0.9.1</version>
+	<summary>A Bookmark manager for Nextcloud</summary>
+	<description><![CDATA[Bookmark manager for Nextcloud]]></description>
+	<version>0.10.0</version>
 	<licence>agpl</licence>
 	<author mail="blizzz@arthur-schiwon.de" homepage="https://www.arthur-schiwon.de">Arthur Schiwon</author>
+	<author mail="mklehr@gmx.net">Marcel Klehr</author>
 	<author>Marvin Thomas Rabe</author>
 	<author>Stefan Klemm</author>
 	<category>organization</category>
@@ -16,8 +17,6 @@
 	<repository type="git">https://github.com/nextcloud/bookmarks.git</repository>
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/bookmarks/master/screenshots/Bookmarks-small.png">https://raw.githubusercontent.com/nextcloud/bookmarks/master/screenshots/Bookmarks.png</screenshot>
 	<dependencies>
-		<owncloud min-version="9.0" max-version="10" />
 		<nextcloud min-version="9" max-version="12" />
 	</dependencies>
-	<ocsid>168710</ocsid>
 </info>


### PR DESCRIPTION
I also thought about remove the ownCloud tests. We had one failing anyway, and there is also a bug report against OC. We have no devs on OC, plus OC  also forked it, so it would be wasted time and false promises.