### PR TITLE
info.xml <owncloud>tag is required for apps that run on Nextcloud 9 and 10

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,6 +17,7 @@
 	<repository type="git">https://github.com/nextcloud/bookmarks.git</repository>
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/bookmarks/master/screenshots/Bookmarks-small.png">https://raw.githubusercontent.com/nextcloud/bookmarks/master/screenshots/Bookmarks.png</screenshot>
 	<dependencies>
+		<owncloud min-version="9.0" max-version="9.2" />
 		<nextcloud min-version="9" max-version="12" />
 	</dependencies>
 </info>


### PR DESCRIPTION
appstore was shouting at me… 😇 