### PR TITLE
Fix bookmarks filter

### DIFF
--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -254,11 +254,12 @@ class Bookmarks {
 		}
 		$filterExpressions = [];
 		$otherColumns = ['b.url', 'b.title', 'b.description'];
-    	$i = 0;
+		$i = 0;
 		foreach ($filters as $filter) {
-			$qb->leftJoin('b', 'bookmarks_tags', 't' . $i, $qb->expr()->eq('t' . $i . '.bookmark_id', 'b.id'));
       		$expr = [];
-			$expr[] = $qb->expr()->eq('t'.$i.'.tag', $qb->createNamedParameter($filter));
+			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter) . ',_%'));
+			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter($this->db->escapeLikeParameter($filter) . ',_%'));
+			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter)));
 			if (!$filterTagOnly) {
 				foreach ($otherColumns as $col) {
 					$expr[] = $qb->expr()->like(
@@ -275,7 +276,7 @@ class Bookmarks {
 		}else {
 			$filterExpression = call_user_func_array([$qb->expr(), 'orX'], $filterExpressions);
 		}
-		$qb->andWhere($filterExpression);
+		$qb->having($filterExpression);
 	}
 
 	/**

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -257,11 +257,11 @@ class Bookmarks {
 		$i = 0;
 		foreach ($filters as $filter) {
       		$expr = [];
-			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('%'.$this->db->escapeLikeParameter($filter).'%'));
+			$expr[] = $qb->expr()->iLike('tags', $qb->createNamedParameter('%'.$this->db->escapeLikeParameter($filter).'%'));
 			if (!$filterTagOnly) {
 				foreach ($otherColumns as $col) {
-					$expr[] = $qb->expr()->like(
-						$qb->createFunction('lower(' . $qb->getColumnName($col) . ')'),
+					$expr[] = $qb->expr()->iLike(
+						$qb->createFunction($qb->getColumnName($col)),
 						$qb->createNamedParameter('%' . $this->db->escapeLikeParameter(strtolower($filter)) . '%')
 					);
 				}

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -257,10 +257,7 @@ class Bookmarks {
 		$i = 0;
 		foreach ($filters as $filter) {
       		$expr = [];
-			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter) . ',_%'));
-			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter($this->db->escapeLikeParameter($filter) . ',_%'));
-			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter)));
-			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter($this->db->escapeLikeParameter($filter)));
+			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('%'.$this->db->escapeLikeParameter($filter).'%'));
 			if (!$filterTagOnly) {
 				foreach ($otherColumns as $col) {
 					$expr[] = $qb->expr()->like(

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -220,7 +220,6 @@ class Bookmarks {
 				$qb->setFirstResult($offset);
 			}
 		}
-
 		$results = $qb->execute()->fetchAll();
 		$bookmarks = array();
 		foreach ($results as $result) {
@@ -255,17 +254,21 @@ class Bookmarks {
 		}
 		$filterExpressions = [];
 		$otherColumns = ['b.url', 'b.title', 'b.description'];
-    $i = 0;
+    	$i = 0;
 		foreach ($filters as $filter) {
-      $qb->leftJoin('b', 'bookmarks_tags', 't' . $i, $qb->expr()->eq('t' . $i . '.bookmark_id', 'b.id'));
-			$filterExpressions[] = $qb->expr()->eq('t'.$i.'.tag', $qb->createNamedParameter($filter));
+			$qb->leftJoin('b', 'bookmarks_tags', 't' . $i, $qb->expr()->eq('t' . $i . '.bookmark_id', 'b.id'));
+      		$expr = [];
+			$expr[] = $qb->expr()->eq('t'.$i.'.tag', $qb->createNamedParameter($filter));
 			if (!$filterTagOnly) {
 				foreach ($otherColumns as $col) {
-					$filterExpressions[] = $qb->expr()->like($qb->createFunction('lower(' . $qb->getColumnName($col) . ')'),
-						$qb->createNamedParameter('%' . $this->db->escapeLikeParameter(strtolower($filter)) . '%'));
+					$expr[] = $qb->expr()->like(
+						$qb->createFunction('lower(' . $qb->getColumnName($col) . ')'),
+						$qb->createNamedParameter('%' . $this->db->escapeLikeParameter(strtolower($filter)) . '%')
+					);
 				}
 			}
-      $i++;
+			$filterExpressions[] = call_user_func_array([$qb->expr(), 'orX'], $expr);
+      		$i++;
 		}
 		if ($connectWord == 'AND') {
 			$filterExpression = call_user_func_array([$qb->expr(), 'andX'], $filterExpressions);

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -260,6 +260,7 @@ class Bookmarks {
 			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter) . ',_%'));
 			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter($this->db->escapeLikeParameter($filter) . ',_%'));
 			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter('_%,' . $this->db->escapeLikeParameter($filter)));
+			$expr[] = $qb->expr()->like('tags', $qb->createNamedParameter($this->db->escapeLikeParameter($filter)));
 			if (!$filterTagOnly) {
 				foreach ($otherColumns as $col) {
 					$expr[] = $qb->expr()->like(

--- a/js/bookmarks.js
+++ b/js/bookmarks.js
@@ -143,7 +143,7 @@ function getBookmarks() {
 	$.ajax({
 		type: 'GET',
 		url: 'bookmark',
-		data: {type: 'bookmark', tag: $('#bookmarkFilterTag').val(), page: bookmarksPage, sort: bookmarksSorting},
+		data: {type: 'bookmark', tag: $('#bookmarkFilterTag').val(), page: bookmarksPage, conjunction: 'and', sort: bookmarksSorting},
 		complete: function () {
 			decreaseAjaxCallCount();
 		},

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -73,7 +73,6 @@ class Test_LibBookmarks_Bookmarks extends TestCase {
 		$this->libBookmarks->addBookmark($secondUser, "http://www.golem.de", "Golem", array("four"), "PublicNoTag", true);
 		$this->libBookmarks->addBookmark($secondUser, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
 		$resultSetOne = $this->libBookmarks->findBookmarks($this->userid, 0, 'lastmodified', array('one', 'three'), true, -1, false, array('url', 'title', 'tags'), 'or');
-		var_dump($resultSetOne);
     $this->assertEquals(3, count($resultSetOne));
 		$resultOne = $resultSetOne[0];
 		$this->assertFalse(isset($resultOne['lastmodified']));
@@ -159,7 +158,6 @@ class Test_LibBookmarks_Bookmarks extends TestCase {
 		$this->assertTrue(in_array(['tag' => 'two', 'nbr' => 2], $firstUserTags));
 		$this->assertTrue(in_array(['tag' => 'four', 'nbr' => 1], $firstUserTags));
 		$this->assertTrue(in_array(['tag' => 'three', 'nbr' => 1], $firstUserTags));
-		var_dump($firstUserTags);
 		$this->assertEquals(count($firstUserTags), 3);
 		$secondUserTags = $this->libBookmarks->findTags($secondUser);
 		$this->assertTrue(in_array(['tag' => 'one', 'nbr' => 2], $secondUserTags));

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -72,11 +72,11 @@ class Test_LibBookmarks_Bookmarks extends TestCase {
 		$this->libBookmarks->addBookmark($secondUser, "http://www.heise.de", "Heise", array("one", "two"), "PrivatTag", false);
 		$this->libBookmarks->addBookmark($secondUser, "http://www.golem.de", "Golem", array("four"), "PublicNoTag", true);
 		$this->libBookmarks->addBookmark($secondUser, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
-		$resultSetOne = $this->libBookmarks->findBookmarks($this->userid, 0, 'lastmodified', array('one', 'three'), true, -1, false, array('url', 'title'), 'or');
+		$resultSetOne = $this->libBookmarks->findBookmarks($this->userid, 0, 'lastmodified', array('one', 'three'), true, -1, false, array('url', 'title', 'tags'), 'or');
 		$this->assertEquals(3, count($resultSetOne));
 		$resultOne = $resultSetOne[0];
 		$this->assertFalse(isset($resultOne['lastmodified']));
-		$this->assertFalse(isset($resultOne['tags']));
+		$this->assertEquals(['one'], $resultOne['tags']);
 	}
 
 	function testFindTags() {

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -73,10 +73,11 @@ class Test_LibBookmarks_Bookmarks extends TestCase {
 		$this->libBookmarks->addBookmark($secondUser, "http://www.golem.de", "Golem", array("four"), "PublicNoTag", true);
 		$this->libBookmarks->addBookmark($secondUser, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
 		$resultSetOne = $this->libBookmarks->findBookmarks($this->userid, 0, 'lastmodified', array('one', 'three'), true, -1, false, array('url', 'title', 'tags'), 'or');
-		$this->assertEquals(3, count($resultSetOne));
+		var_dump($resultSetOne);
+    $this->assertEquals(3, count($resultSetOne));
 		$resultOne = $resultSetOne[0];
 		$this->assertFalse(isset($resultOne['lastmodified']));
-		$this->assertEquals(['one'], $resultOne['tags']);
+		$this->assertEquals(['three', 'two'], $resultOne['tags']);
 	}
 
 	function testFindTags() {


### PR DESCRIPTION
used to use AND for different item columns as well which is plain wrong.
Also, client-side didn't supply a conjunction overriding the default OR (fixes #366).