### PR TITLE
New REST endpoint: read single bookmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,32 @@ POST /apps/bookmarks/public/rest/v2/bookmark?url=http%3A%2F%2Fgoogle.com&title=G
 }
 ```
 
+### Get a bookmark
+```
+GET /apps/bookmarks/public/rest/v2/bookmark/:id
+```
+
+* `id`: The id of the bookmark to edit
+
+Parameters:
+* (optional) `user`: The user this bookmark belongs to
+
+Example:
+```
+GET /apps/bookmarks/public/rest/v2/bookmark/7
+```
+
+```json
+{ "status": "success",
+  "item": {
+    "id": "7",
+	  "url": "http://google.com",
+  	"title": "Boogle",
+  	//...
+  }
+}
+```
+
 ### Edit a bookmark
 ```
 PUT /apps/bookmarks/public/rest/v2/bookmark/:id

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,6 +27,7 @@ $application->registerRoutes($this, array('routes' => array(
 	//internal REST API
 	array('name' => 'internal_bookmark#get_bookmarks', 'url' => '/bookmark', 'verb' => 'GET'),
 	array('name' => 'internal_bookmark#new_bookmark', 'url' => '/bookmark', 'verb' => 'POST'),
+	array('name' => 'internal_bookmark#get_single_bookmark', 'url' => '/bookmark/{id}', 'verb' => 'GET'),
 	array('name' => 'internal_bookmark#edit_bookmark', 'url' => '/bookmark/{id}', 'verb' => 'PUT'),
 	array('name' => 'internal_bookmark#delete_bookmark', 'url' => '/bookmark/{id}', 'verb' => 'DELETE'),
 	array('name' => 'internal_bookmark#click_bookmark', 'url' => '/bookmark/click', 'verb' => 'POST'),
@@ -38,6 +39,7 @@ $application->registerRoutes($this, array('routes' => array(
 	// Public REST API
 	array('name' => 'bookmark#get_bookmarks', 'url' => '/public/rest/v2/bookmark', 'verb' => 'GET'),
 	array('name' => 'bookmark#new_bookmark', 'url' => '/public/rest/v2/bookmark', 'verb' => 'POST'),
+	array('name' => 'bookmark#get_single_bookmark', 'url' => '/public/rest/v2/bookmark/{id}', 'verb' => 'GET'),
 	array('name' => 'bookmark#edit_bookmark', 'url' => '/public/rest/v2/bookmark/{id}', 'verb' => 'PUT'),
 	array('name' => 'bookmark#delete_bookmark', 'url' => '/public/rest/v2/bookmark/{id}', 'verb' => 'DELETE'),
 	array('name' => 'bookmark#click_bookmark', 'url' => '/public/rest/v2/bookmark/click', 'verb' => 'POST'),

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -78,7 +78,7 @@ class BookmarkController extends ApiController {
 			}
 		}
 		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
-		if ($public_only === TRUE && $bm['public'] !== '1') {
+		if ($public_only === TRUE && $bm['public'] != '1') {
 			$error = "Insufficient permissions";
 			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
     }

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -269,7 +269,7 @@ class BookmarkController extends ApiController {
 		$newProps = [
 			'url' => $url,
 			'title' => $title,
-			'is_public' => $is_public,
+			'public' => $is_public,
 			'description' => $description
 		];
 		if (is_array($item) && isset($item['tags']) && is_array($item['tags'])) {
@@ -291,7 +291,7 @@ class BookmarkController extends ApiController {
 			$bookmark['tags'] = [];
 		}
 
-		$id = $this->bookmarks->editBookmark($this->userId, $bookmark['id'], $bookmark['url'], $bookmark['title'], $bookmark['tags'], $bookmark['description'], $bookmark['is_public']);
+		$id = $this->bookmarks->editBookmark($this->userId, $bookmark['id'], $bookmark['url'], $bookmark['title'], $bookmark['tags'], $bookmark['description'], $bookmark['public']);
 
 		$bm = $this->bookmarks->findUniqueBookmark($id, $this->userId);
 		return new JSONResponse(array('item' => $bm, 'status' => 'success'));

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -65,21 +65,21 @@ class BookmarkController extends ApiController {
 	 */
 	public function getSingleBookmark(
 		$id,
-    $user = null
+		$user = null
 	) {
 		if ($user === null) {
 			$user = $this->userId;
-			$publicOnly = false;
+			$public_only = false;
 		}else {
-			$publicOnly = true;
+			$public_only = true;
 			if ($this->userManager->userExists($user) == false) {
 				$error = "User could not be identified";
 				return new JSONResponse(array('status' => 'error', 'data'=> $error), Http::STATUS_BAD_REQUEST);
 			}
 		}
 		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
-    if ($publicOnly === TRUE && $bm['public'] !== '1') {
-      $error = "Insufficient permissions";
+		if ($public_only === TRUE && $bm['public'] !== '1') {
+			$error = "Insufficient permissions";
 			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
     }
 		return new JSONResponse(array('item' => $bm, 'status' => 'success'));

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -54,6 +54,35 @@ class BookmarkController extends ApiController {
 	public function legacyGetBookmarks($type = "bookmark", $tag = '', $page = 0, $sort = "bookmarks_sorting_recent") {
 		return $this->getBookmarks($type, $tag, $page, $sort);
 	}
+	
+  /**
+	 * @param string $id
+	 * @return JSONResponse
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @CORS
+	 */
+	public function getSingleBookmark(
+		$id,
+    $user = null
+	) {
+		if ($user === null) {
+			$user = $this->userId;
+			$publicOnly = false;
+		}else {
+			$publicOnly = true;
+			if ($this->userManager->userExists($user) == false) {
+				$error = "User could not be identified";
+				return new JSONResponse(array('status' => 'error', 'data'=> $error), Http::STATUS_BAD_REQUEST);
+			}
+		}
+		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
+    if ($publicOnly === TRUE && $bm['public'] !== '1') {
+			return new JSONResponse(array(), Http::STATUS_BAD_REQUEST);
+    }
+		return new JSONResponse(array('item' => $bm, 'status' => 'success'));
+  }
 
 	/**
 	 * @param string $type

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -69,21 +69,24 @@ class BookmarkController extends ApiController {
 	) {
 		if ($user === null) {
 			$user = $this->userId;
-			$public_only = false;
+			$publicOnly = false;
 		}else {
-			$public_only = true;
+			$publicOnly = true;
 			if ($this->userManager->userExists($user) == false) {
 				$error = "User could not be identified";
 				return new JSONResponse(array('status' => 'error', 'data'=> $error), Http::STATUS_BAD_REQUEST);
 			}
 		}
 		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
-		if ($public_only === TRUE && $bm['public'] != '1') {
-			$error = "Insufficient permissions";
+		if(!isset($bm['id'])) {
+			return new JSONResponse(['status' => 'error'], Http::STATUS_NOT_FOUND);
+		}
+		if ($public_only === true && isset($bm['public']) && $bm['public'] != '1') {
+            $error = "Insufficient permissions";
 			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
-    }
+    	}
 		return new JSONResponse(array('item' => $bm, 'status' => 'success'));
-  }
+	}
 
 	/**
 	 * @param string $type

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -79,7 +79,7 @@ class BookmarkController extends ApiController {
 		}
 		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
     if ($publicOnly === TRUE && $bm['public'] !== '1') {
-      $error = "Insufficient permissions"
+      $error = "Insufficient permissions";
 			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
     }
 		return new JSONResponse(array('item' => $bm, 'status' => 'success'));

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -79,7 +79,8 @@ class BookmarkController extends ApiController {
 		}
 		$bm = $this->bookmarks->findUniqueBookmark($id, $user);
     if ($publicOnly === TRUE && $bm['public'] !== '1') {
-			return new JSONResponse(array(), Http::STATUS_BAD_REQUEST);
+      $error = "Insufficient permissions"
+			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
     }
 		return new JSONResponse(array('item' => $bm, 'status' => 'success'));
   }

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -81,7 +81,7 @@ class BookmarkController extends ApiController {
 		if(!isset($bm['id'])) {
 			return new JSONResponse(['status' => 'error'], Http::STATUS_NOT_FOUND);
 		}
-		if ($public_only === true && isset($bm['public']) && $bm['public'] != '1') {
+		if ($publicOnly === true && isset($bm['public']) && $bm['public'] != '1') {
             $error = "Insufficient permissions";
 			return new JSONResponse(array('status' => 'error', 'data' => $error), Http::STATUS_BAD_REQUEST);
     	}

--- a/controller/rest/internalbookmarkcontroller.php
+++ b/controller/rest/internalbookmarkcontroller.php
@@ -55,6 +55,17 @@ class InternalBookmarkController extends ApiController {
 	) {
 		return $this->publicController->getBookmarks($type, $tag, $page, $sort, $user, $tags, $conjunction, $sortby, $search);
 	}
+	
+  /**
+	 * @param string $id
+	 * @param string $user
+	 * @return JSONResponse
+	 *
+	 * @NoAdminRequired
+	 */
+	public function getSingleBookmark($id, $user = null) {
+		return $this->publicController->getSingleBookmark($id, $user);
+	}
 
 	/**
 	 * @param string $url

--- a/tests/bookmarkcontroller_test.php
+++ b/tests/bookmarkcontroller_test.php
@@ -59,7 +59,7 @@ class Test_BookmarkController extends TestCase {
   function testPrivateRead() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->userid);
+		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId);
 		$data = $output->getData();
 		$this->assertEquals('success', $data['status']);
 		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
@@ -68,7 +68,7 @@ class Test_BookmarkController extends TestCase {
   function testPublicReadSuccess() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->otherUser);
+		$output = $this->publicController->getSingleBookmark($this->testSubjectPublicBmId, $this->userid);
 		$data = $output->getData();
 		$this->assertEquals('success', $data['status']);
 		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
@@ -77,7 +77,7 @@ class Test_BookmarkController extends TestCase {
   function testPublicReadFailure() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPrivateBmId, $this->otherUser);
+		$output = $this->publicController->getSingleBookmark($this->testSubjectPrivateBmId, $this->userid);
 		$data = $output->getData();
 		$this->assertEquals('error', $data['status']);
 	}

--- a/tests/bookmarkcontroller_test.php
+++ b/tests/bookmarkcontroller_test.php
@@ -59,10 +59,10 @@ class Test_BookmarkController extends TestCase {
   function testPrivateRead() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, this->userid);
+		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->userid);
 		$data = $output->getData();
-		$this->assertEquals('success', $data['status']));
-		$this->assertEquals("http://www.9gag.com", $data['data']['url']));
+		$this->assertEquals('success', $data['status']);
+		$this->assertEquals("http://www.9gag.com", $data['data']['url']);
 	}
 
   function testPublicReadSuccess() {
@@ -70,8 +70,8 @@ class Test_BookmarkController extends TestCase {
 		$this->setupBookmarks();
 		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->otheruser);
 		$data = $output->getData();
-		$this->assertEquals('success', $data['status']));
-		$this->assertEquals("http://www.9gag.com", $data['data']['url']));
+		$this->assertEquals('success', $data['status']);
+		$this->assertEquals("http://www.9gag.com", $data['data']['url']);
 	}
   
   function testPublicReadFailure() {
@@ -79,7 +79,7 @@ class Test_BookmarkController extends TestCase {
 		$this->setupBookmarks();
 		$output = $this->controller->getSingleBookmark($this->testSubjectPrivateBmId, $this->otheruser);
 		$data = $output->getData();
-		$this->assertEquals('error', $data['status']));
+		$this->assertEquals('error', $data['status']);
 	}
 
 	function testPrivateQuery() {

--- a/tests/bookmarkcontroller_test.php
+++ b/tests/bookmarkcontroller_test.php
@@ -62,22 +62,22 @@ class Test_BookmarkController extends TestCase {
 		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->userid);
 		$data = $output->getData();
 		$this->assertEquals('success', $data['status']);
-		$this->assertEquals("http://www.9gag.com", $data['data']['url']);
+		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
 	}
 
   function testPublicReadSuccess() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->otheruser);
+		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->otherUser);
 		$data = $output->getData();
 		$this->assertEquals('success', $data['status']);
-		$this->assertEquals("http://www.9gag.com", $data['data']['url']);
+		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
 	}
   
   function testPublicReadFailure() {
 		$this->cleanDB();
 		$this->setupBookmarks();
-		$output = $this->controller->getSingleBookmark($this->testSubjectPrivateBmId, $this->otheruser);
+		$output = $this->controller->getSingleBookmark($this->testSubjectPrivateBmId, $this->otherUser);
 		$data = $output->getData();
 		$this->assertEquals('error', $data['status']);
 	}

--- a/tests/bookmarkcontroller_test.php
+++ b/tests/bookmarkcontroller_test.php
@@ -56,7 +56,7 @@ class Test_BookmarkController extends TestCase {
 		$this->testSubjectPublicBmId = $this->libBookmarks->addBookmark($this->userid, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
 	}
 	
-  function testPrivateRead() {
+	function testPrivateRead() {
 		$this->cleanDB();
 		$this->setupBookmarks();
 		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId);
@@ -65,7 +65,7 @@ class Test_BookmarkController extends TestCase {
 		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
 	}
 
-  function testPublicReadSuccess() {
+	function testPublicReadSuccess() {
 		$this->cleanDB();
 		$this->setupBookmarks();
 		$output = $this->publicController->getSingleBookmark($this->testSubjectPublicBmId, $this->userid);
@@ -74,13 +74,22 @@ class Test_BookmarkController extends TestCase {
 		$this->assertEquals("http://www.9gag.com", $data['item']['url']);
 	}
   
-  function testPublicReadFailure() {
+	function testPublicReadFailure() {
 		$this->cleanDB();
 		$this->setupBookmarks();
 		$output = $this->publicController->getSingleBookmark($this->testSubjectPrivateBmId, $this->userid);
 		$data = $output->getData();
 		$this->assertEquals('error', $data['status']);
 	}
+
+	function testPrivateReadNotFound() {
+       $this->cleanDB();
+       $this->setupBookmarks();
+       $output = $this->controller->getSingleBookmark(987);
+       $data = $output->getData();
+       $this->assertSame('error', $data['status']);
+       $this->assertSame(404, $output->getStatus());
+   }
 
 	function testPrivateQuery() {
 		$this->cleanDB();

--- a/tests/bookmarkcontroller_test.php
+++ b/tests/bookmarkcontroller_test.php
@@ -52,8 +52,34 @@ class Test_BookmarkController extends TestCase {
 	}
 
 	function setupBookmarks() {
-		$this->libBookmarks->addBookmark($this->userid, "http://www.golem.de", "Golem", array("four"), "PublicNoTag", false);
-		$this->libBookmarks->addBookmark($this->userid, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
+		$this->testSubjectPrivateBmId = $this->libBookmarks->addBookmark($this->userid, "http://www.golem.de", "Golem", array("four"), "PublicNoTag", false);
+		$this->testSubjectPublicBmId = $this->libBookmarks->addBookmark($this->userid, "http://www.9gag.com", "9gag", array("two", "three"), "PublicTag", true);
+	}
+	
+  function testPrivateRead() {
+		$this->cleanDB();
+		$this->setupBookmarks();
+		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, this->userid);
+		$data = $output->getData();
+		$this->assertEquals('success', $data['status']));
+		$this->assertEquals("http://www.9gag.com", $data['data']['url']));
+	}
+
+  function testPublicReadSuccess() {
+		$this->cleanDB();
+		$this->setupBookmarks();
+		$output = $this->controller->getSingleBookmark($this->testSubjectPublicBmId, $this->otheruser);
+		$data = $output->getData();
+		$this->assertEquals('success', $data['status']));
+		$this->assertEquals("http://www.9gag.com", $data['data']['url']));
+	}
+  
+  function testPublicReadFailure() {
+		$this->cleanDB();
+		$this->setupBookmarks();
+		$output = $this->controller->getSingleBookmark($this->testSubjectPrivateBmId, $this->otheruser);
+		$data = $output->getData();
+		$this->assertEquals('error', $data['status']));
 	}
 
 	function testPrivateQuery() {


### PR DESCRIPTION
So, in order to add a tag without deleting the already existing ones, you need to know what tags are already set. Unfortunately there's no way to get that info on a single bookmark without fetching them all at once (uff.), ... until now :)

This pr adds a REST endpoint that proxies libBookmarks#findUniqueBookmark and even takes care of public/private bookmarks.