### PR TITLE
UI: Don't escape URL for editing a bookmark

### DIFF
--- a/templates/js_tpl.php
+++ b/templates/js_tpl.php
@@ -29,7 +29,7 @@
             </p>
             <p class="bookmark_form_url">
                 <input type="text" name="url" placeholder="<?php p($l->t('The address of the page')); ?>"
-                       value="<&= encodeURI(url)&>"/>
+                       value="<&= escapeHTML(url)&>"/>
             </p>
             <div class="bookmark_form_tags"><ul>
                     <& for ( var i = 0; i < tags.length; i++ ) { &>


### PR DESCRIPTION
fixes #401

Actually, the url is still escaped, but not for use as a url, but for use as an HTML attribute value...