### PR TITLE
exportBookmarks would export records with no URL and this would break…

### DIFF
--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -433,8 +433,9 @@ EOT;
 			$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 			$description = htmlspecialchars($bm['description'], ENT_QUOTES, 'UTF-8');
 
-			$file .= '<DT><A HREF="' . $url . '" TAGS="' . $tags . '">' . $title . '</A><DD>' . $description . "\n";
-
+			$file .= '<DT><A HREF="' . $url . '" TAGS="' . $tags . '">' . $title . '</A>';
+			if(strlen($description)>0) $file .= '<DD>' . $description;
+			$file .= . "\n";
 		}
 
 		return new ExportResponse($file);

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -415,17 +415,26 @@ Do Not Edit! -->
 <DL><p>
 EOT;
 		$bookmarks = $this->bookmarks->findBookmarks($this->userId, 0, 'id', [], true, -1);
+
 		foreach ($bookmarks as $bm) {
-			$title = $bm['title'];
-			if (trim($title) === '') {
+
+			$url = \OC_Util::sanitizeHTML($bm['url']);
+
+			// discards records with no URL. This should not happen but 
+			// a database could have old entries
+			if ($url === '') continue;
+
+			$tags = implode(',', \OC_Util::sanitizeHTML($bm['tags']));
+			$title = trim($bm['title']);
+			if ($title === '') {
 				$url_parts = parse_url($bm['url']);
-				$title = isset($url_parts['host']) ? Helper::getDomainWithoutExt($url_parts['host']) : $bm['url'];
+				$title = isset($url_parts['host']) ? Helper::getDomainWithoutExt($url_parts['host']) : $url;
 			}
-			$file .= '<DT><A HREF="' . \OC_Util::sanitizeHTML($bm['url']) . '" TAGS="' . implode(',', \OC_Util::sanitizeHTML($bm['tags'])) . '">';
-			$file .= htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '</A>';
-			if ($bm['description'])
-				$file .= '<DD>' . htmlspecialchars($bm['description'], ENT_QUOTES, 'UTF-8');
-			$file .= "\n";
+			$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+			$description = htmlspecialchars($bm['description'], ENT_QUOTES, 'UTF-8');
+
+			$file .= '<DT><A HREF="' . $url . '" TAGS="' . $tags . '">' . $title . '</A><DD>' . $description . "\n";
+
 		}
 
 		return new ExportResponse($file);


### PR DESCRIPTION
exportBookmarks would export records with no URL and this would break the import. Fixed.
I've tested both the export and the import on my own list of bookmarks (which had some records with bad URL due to a former import) and it worked.