### PR TITLE
Fix typos in variable name

### DIFF
--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -676,7 +676,7 @@ class Bookmarks {
 
 			$descriptionStr = '';
 			if ($link->hasAttribute("description")) {
-				$desc_str = $link->getAttribute("description");
+				$descriptionStr = $link->getAttribute("description");
 			} else {
 				/* Get description from a following <DD> when link in a
 				 * <DT> (e.g., Delicious export, firefox) */
@@ -684,7 +684,7 @@ class Bookmarks {
 				if ($parent && $parent->tagName == "dt") {
 					$dd = $parent->nextSibling;
 					if ($dd->tagName == "dd") {
-						$desc_str = trim($dd->nodeValue);
+						$descriptionStr = trim($dd->nodeValue);
 					}
 				}
 			}


### PR DESCRIPTION
Two different variable names are used for the bookmark description when importing which causes the description to never import.

This change standardizes the variable names.