### PR TITLE
Fix tag editing

### DIFF
--- a/controller/rest/tagscontroller.php
+++ b/controller/rest/tagscontroller.php
@@ -69,11 +69,11 @@ class TagsController extends ApiController {
 	 * @CORS
 	 */
 	public function fullTags($count=FALSE) {
-		
+
 		header("Cache-Control: no-cache, must-revalidate");
 		header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
-		
-		$qtags = $this->bookmarks->findTags($this->userId, array(), 0, 400);
+
+		$qtags = $this->bookmarks->findTags($this->userId, array(), 0);
 		$tags = array();
 		foreach ($qtags as $tag) {
 			if ($count === TRUE) {

--- a/js/views/BookmarkDetail.js
+++ b/js/views/BookmarkDetail.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
+import Tag from '../models/Tag';
 import Tags from '../models/Tags';
 import TagsNavigationView from './TagsNavigation';
 import TagsSelectionView from './TagsSelection';
@@ -38,13 +39,14 @@ export default Marionette.View.extend({
 		this.listenTo(this.model, 'change', this.render);
 		this.listenTo(this.model, 'destroy', this.onDestroy);
 		this.listenTo(this.app.tags, 'sync', this.render);
-	},
-	onRender: function() {
+
 		var that = this;
 		this.tags = new Tags(this.model.get('tags').map(function(id) {
 			return that.app.tags.get(id);
 		}));
 		this.listenTo(this.tags, 'add remove', this.submitTags);
+	},
+	onRender: function() {
 		this.showChildView('tags', new TagsSelectionView({collection: this.app.tags, selected: this.tags, app: this.app }));
 
 		if (this.savingState === 'saving') {
@@ -95,6 +97,7 @@ export default Marionette.View.extend({
 		$el.focus();
 	},
 	submitTags: function() {
+		this.app.tags.add(this.tags.models)
 		this.model.set({
 			'tags': this.tags.pluck('name'),
 		});

--- a/js/views/TagsSelection.js
+++ b/js/views/TagsSelection.js
@@ -22,7 +22,6 @@ export default Marionette.View.extend({
 		this.listenTo(this.selected, 'add', this.onChangeByAlgo);
 		this.listenTo(this.selected, 'remove', this.onChangeByAlgo);
 		this.listenTo(this.selected, 'reset', this.onChangeByAlgo);
-		this.listenTo(this.collection, 'add', this.onAttach);
 	},
 	onAttach: function() {
 		if (this.$el.hasClass('select2-hidden-accessible')) {
@@ -45,12 +44,12 @@ export default Marionette.View.extend({
 		this.$el.select2('destroy');
 	},
 	onAddByUser: function(e) {
-		var tag = this.app.tags.get(e.params.data.text) || new Tag({name: e.params.data.text});
+		var tag = this.app.tags.get(e.params.data.text) ||
+			new Tag({name: e.params.data.text, count: 1});
 		this.selected.add(tag);
 	},
 	onRemoveByUser: function(e) {
-		var tag = this.app.tags.get(e.params.data.text) || new Tag({name: e.params.data.text});
-		this.selected.remove(tag);
+		this.selected.remove(e.params.data.text);
 	},
 	onChangeByAlgo: function(e) {
 		this.$el


### PR DESCRIPTION
fixes #508 

The problem was that the endpoint only returned a maximum of 400 tags. Thus the app didn't have the complete tag list and the instantiation of tags per bookmark didn't work, as the bookmark tries to fetch the tag instances from the central list, which wasn't complete. It is now.