### PR TITLE
Added missing translation

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -15,6 +15,7 @@ OC.L10N.register(
     "Tags" : "Schlagworte",
     "Description" : "Beschreibung",
     "No bookmarks here." : "Keine Lesezeichen vorhanden.",
+    "There are no bookmarks available for this query. Try changing your filter or add some using the menu entry on the left." : "Für diese Abfrage sind keine Lesezeichen verfügbar. Ändern Sie Ihren Filter oder fügen Sie Lesezeichen hinzu, indem Sie den Menüeintrag auf der linken Seite verwenden.",
     "Favorites" : "Favoriten",
     "Settings" : "Einstellungen",
     "Bookmarklet" : "Bookmarklet",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -13,6 +13,7 @@
     "Tags" : "Schlagworte",
     "Description" : "Beschreibung",
     "No bookmarks here." : "Keine Lesezeichen vorhanden.",
+    "There are no bookmarks available for this query. Try changing your filter or add some using the menu entry on the left." : "Für diese Abfrage sind keine Lesezeichen verfügbar. Ändern Sie Ihren Filter oder fügen Sie Lesezeichen hinzu, indem Sie den Menüeintrag auf der linken Seite verwenden.",
     "Favorites" : "Favoriten",
     "Settings" : "Einstellungen",
     "Bookmarklet" : "Bookmarklet",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -15,6 +15,7 @@ OC.L10N.register(
     "Tags" : "Schlagworte",
     "Description" : "Beschreibung",
     "No bookmarks here." : "Keine Lesezeichen vorhanden",
+    "There are no bookmarks available for this query. Try changing your filter or add some using the menu entry on the left." : "Für diese Abfrage sind keine Lesezeichen verfügbar. Ändern Sie Ihren Filter oder fügen Sie Lesezeichen hinzu, indem Sie den Menüeintrag auf der linken Seite verwenden.",
     "Favorites" : "Favoriten",
     "Settings" : "Einstellungen",
     "Bookmarklet" : "Bookmarklet",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -13,6 +13,7 @@
     "Tags" : "Schlagworte",
     "Description" : "Beschreibung",
     "No bookmarks here." : "Keine Lesezeichen vorhanden",
+    "There are no bookmarks available for this query. Try changing your filter or add some using the menu entry on the left." : "Für diese Abfrage sind keine Lesezeichen verfügbar. Ändern Sie Ihren Filter oder fügen Sie Lesezeichen hinzu, indem Sie den Menüeintrag auf der linken Seite verwenden.",
     "Favorites" : "Favoriten",
     "Settings" : "Einstellungen",
     "Bookmarklet" : "Bookmarklet",


### PR DESCRIPTION
"There are no bookmarks available for this query. Try changing your filter or add some using the menu entry on the left."
The sentence is currently not translated and shown in english when using the german interface.

Therefore it should be translated:
"Für diese Abfrage sind keine Lesezeichen verfügbar. Ändern Sie Ihren Filter oder fügen Sie Lesezeichen hinzu, indem Sie den Menüeintrag auf der linken Seite verwenden."