### PR TITLE
Added another 3d-party client (Owncloud bookmarks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npm run build
 ## Third-party clients
 
 - [Nextcloud Bookmarks](https://gitlab.com/derSchabi/OCBookmarks) - client app for Android ([new PlayStore entry](https://play.google.com/store/apps/details?id=org.bisw.nxbookmarks))
+- [Owncloud Bookmarks](https://chrome.google.com/webstore/detail/owncloud-bookmarks/eomolhpeokmbnincelpkagpapjpeeckc?hl=de
+) - Bookmarks extension for Chromium-based browsers (Chromium/Chrome/Opera/Vivaldi)
 - [Floccus](https://github.com/marcelklehr/floccus) - Bookmark sync for Firefox/Chromium-based
 - [NCBookmarks](https://github.com/lenchan139/NCBookmark) - Android App
 - [uMarks](https://uappexplorer.com/app/umarks.ernesst) - App for Ubuntu touch


### PR DESCRIPTION
There is another 3rd-party client by Martin Jakl called "Owncloud Bookmarks". It works on all Chromium-based browsers and is very useful because it doesn't directly sync a complete folder like Floccus but allows access through a drop down list within the extension.