### PR TITLE
Fix some translation problems

### DIFF
--- a/src/components/BookmarksList.vue
+++ b/src/components/BookmarksList.vue
@@ -21,8 +21,8 @@
 		<div
 			v-else-if="!loading && !folderChildren.length"
 			class="bookmarkslist__empty">
-			<h2>No bookmarks here</h2>
-			<p>Try changing your query or add some using the button on the left.</p>
+			<h2>{{ t('bookmarks', 'No bookmarks here') }}</h2>
+			<p>{{ t('bookmarks', 'Try changing your query or add some using the button on the left.') }}</p>
 		</div>
 		<div v-if="loading" class="bookmarkslist__loading">
 			<figure class="icon-loading" />

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -47,8 +47,7 @@
 			</Actions>
 			<div v-if="selection.length" class="breadcrumbs__bulkediting">
 				{{
-					n(
-						'bookmarks',
+					n('bookmarks',
 						'Selected %n bookmark',
 						'Selected %n bookmarks',
 						selection.length

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -42,7 +42,7 @@
 							: 'icon-toggle-filelist'
 					"
 					@click="onToggleViewMode">
-					{{ t('bookmarks', viewMode === 'list' ? 'Grid view' : 'List view') }}
+					{{ viewMode === 'list' ? t('bookmarks', 'Grid view') : t('bookmarks', 'List view') }}
 				</ActionButton>
 			</Actions>
 			<div v-if="selection.length" class="breadcrumbs__bulkediting">

--- a/src/components/MoveDialog.vue
+++ b/src/components/MoveDialog.vue
@@ -36,23 +36,20 @@ export default {
 		title() {
 			if (this.selection.folders.length) {
 				if (this.selection.bookmarks.length) {
-					return n(
-						'bookmarks',
+					return n('bookmarks',
 						'Moving %n folder and some bookmarks',
 						'Moving %n folders and some bookmarks',
 						this.selection.folders.length
 					)
 				} else {
-					return n(
-						'bookmarks',
+					return n('bookmarks',
 						'Moving %n folder',
 						'Moving %n folders',
 						this.selection.folders.length
 					)
 				}
 			} else {
-				return n(
-					'bookmarks',
+				return n('bookmarks',
 					'Moving %n bookmark',
 					'Moving %n bookmarks',
 					this.selection.bookmarks.length

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -30,8 +30,7 @@
 		<label>{{ t('bookmarks', 'RSS Feed') }}
 			<input
 				v-tooltip="
-					t(
-						'bookmarks',
+					t('bookmarks',
 						'This is an RSS feed of the current result set with access restricted to you.'
 					)
 				"
@@ -43,8 +42,7 @@
 		<label>{{ t('bookmarks', 'Clear data') }}
 			<button
 				v-tooltip="
-					t(
-						'bookmarks',
+					t('bookmarks',
 						'Permanently remove all bookmarks from your account. There is no going back!'
 					)
 				"
@@ -58,8 +56,7 @@
 		<label>{{ t('bookmarks', 'Bookmarklet') }}
 			<a
 				v-tooltip="
-					t(
-						'bookmarks',
+					t('bookmarks',
 						'Drag this to your browser bookmarks and click it to quickly bookmark a webpage'
 					)
 				"
@@ -74,8 +71,7 @@
 
 		<p>
 			{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'Also check out the collection of client apps that integrate with this app: '
 				)
 			}}

--- a/src/components/ViewAdmin.vue
+++ b/src/components/ViewAdmin.vue
@@ -5,8 +5,7 @@
 		<h2>{{ t('bookmarks', 'Previews') }}</h2>
 		<p>
 			{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'In order to display real screenshots of your bookmarked websites, Bookmarks can use a third-party service to generate those.'
 				)
 			}}
@@ -14,8 +13,7 @@
 		<h3>{{ t('bookmarks', 'Screeenly') }}</h3>
 		<p>
 			{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'You can either sign up for free at screeenly.com or setup your own server.'
 				)
 			}}
@@ -37,8 +35,7 @@
 		<h2>{{ t('bookmarks', 'Privacy') }}</h2>
 		<p>
 			{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'Bookmarks will try to access web pages that you add to automatically add information about them.'
 				)
 			}}
@@ -51,8 +48,7 @@
 				class="checkbox"
 				@input="onChange">
 			<label for="enableScraping">{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'Enable accessing and collecting information from the web pages you add'
 				)
 			}}</label>
@@ -60,16 +56,14 @@
 		<h2>{{ t('bookmarks', 'Performance') }}</h2>
 		<p>
 			{{
-				t(
-					'bookmarks',
+				t('bookmarks',
 					'In an installation with  a lot of users it may be useful to restrict the number of bookmarks per account.'
 				)
 			}}
 		</p>
 		<p>
 			<label for="enableScraping">{{
-					t(
-						'bookmarks',
+					t('bookmarks',
 						'Maximum allowed number of bookmarks per account. (0 for no limit; default is no limit)'
 					)
 				}}


### PR DESCRIPTION
In this PR, I made some strings translatable.
Additionally, I changed some whitespace for several other translations, since the [translation tool](https://github.com/nextcloud/docker-ci/blob/8daabc1bdf7a37af01f7dc0e7cc2a4a68465b1f1/translations/translationtool/src/translationtool.php) doesn't recognize them if there is whitespace between the opening bracket and the first quotation mark. I'm also working on a PR to allow for whitespace there.