### PR TITLE
Make folders clickable

### DIFF
--- a/src/components/Folder.vue
+++ b/src/components/Folder.vue
@@ -1,10 +1,11 @@
 <template>
-	<div :class="{folder: true, 'folder--gridview': viewMode === 'grid'}" @click="onSelect">
-		<figure class="folder__icon icon-folder" />
+	<div :class="{folder: true, 'folder--gridview': viewMode === 'grid'}">
+		<figure class="folder__icon icon-folder" @click="onSelect" />
 		<template v-if="!renaming">
 			<h3
 				class="folder__title"
-				:title="folder.title">
+				:title="folder.title"
+				@click="onSelect">
 				{{ folder.title }}
 			</h3>
 			<Actions class="folder__actions">
@@ -93,7 +94,6 @@ export default {
 	display: flex;
 	align-items: center;
 	position: relative;
-	cursor: pointer;
 }
 
 .folder:hover {
@@ -106,6 +106,7 @@ export default {
 	width: 20px;
 	background-size: cover;
 	margin: 15px;
+	cursor: pointer;
 }
 
 .folder--gridview .folder__icon {
@@ -123,6 +124,7 @@ export default {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
+	cursor: pointer;
 	margin: 0;
 	padding: 15px 0;
 }

--- a/src/components/Folder.vue
+++ b/src/components/Folder.vue
@@ -1,11 +1,10 @@
 <template>
-	<div :class="{folder: true, 'folder--gridview': viewMode === 'grid'}">
+	<div :class="{folder: true, 'folder--gridview': viewMode === 'grid'}" @click="onSelect">
 		<figure class="folder__icon icon-folder" />
 		<template v-if="!renaming">
 			<h3
 				class="folder__title"
-				:title="folder.title"
-				@click="onSelect">
+				:title="folder.title">
 				{{ folder.title }}
 			</h3>
 			<Actions class="folder__actions">

--- a/src/components/Folder.vue
+++ b/src/components/Folder.vue
@@ -93,6 +93,7 @@ export default {
 	display: flex;
 	align-items: center;
 	position: relative;
+	cursor: pointer;
 }
 
 .folder:hover {
@@ -122,7 +123,6 @@ export default {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	cursor: pointer;
 	margin: 0;
 	padding: 15px 0;
 }


### PR DESCRIPTION
### Problem
Currently in order to navigate bookmark folders you have to click on the title of the folder, which is not ideal. Users expect to be able to click on the folder itself to open it, which is how files folders work.

### Propose solution
Have the whole icon be clickable.

Note that a similar argument could be made for the bookmarks themselves, although there perhaps one could expect to click on the URL itself, so sticking to just folders on this PR.