### PR TITLE
Fix tag and count display in navigation sidebar.

### DIFF
--- a/lib/Db/TagMapper.php
+++ b/lib/Db/TagMapper.php
@@ -33,14 +33,14 @@ class TagMapper {
 	public function findAllWithCount($userId) {
 		$qb = $this->db->getQueryBuilder();
 		$qb
-			->select('t.tag')
-			->selectAlias($qb->createFunction('COUNT(' . $qb->getColumnName('t.bookmark_id') . ')'), 'nbr')
+			->select('t.tag AS name')
+			->selectAlias($qb->createFunction('COUNT(' . $qb->getColumnName('t.bookmark_id') . ')'), 'count')
 			->from('bookmarks_tags', 't')
 			->innerJoin('t', 'bookmarks', 'b', $qb->expr()->eq('b.id', 't.bookmark_id'))
 			->where($qb->expr()->eq('b.user_id', $qb->createNamedParameter($userId)));
 		$qb
 			->groupBy('t.tag')
-			->orderBy('nbr', 'DESC');
+			->orderBy('count', 'DESC');
 
 		return $qb->execute()->fetchAll();
 	}

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -37,26 +37,26 @@ export default {
 	computed: {
 		tagMenu() {
 			return this.$store.state.tags.map(tag => ({
-				router: { name: 'tags', params: { tags: tag.name } },
+				router: { name: 'tags', params: { tags: tag.tag } },
 				icon: 'icon-tag',
-				classes: this.editingTag === tag.name ? ['editing'] : [],
-				text: tag.name,
+				classes: this.editingTag === tag.tag ? ['editing'] : [],
+				text: tag.tag,
 				edit: {
-					action: e => this.onRenameTag(tag.name, e.target.elements[0].value),
-					reset: () => this.setEditingTag(tag.name, false),
+					action: e => this.onRenameTag(tag.tag, e.target.elements[0].value),
+					reset: () => this.setEditingTag(tag.tag, false),
 				},
 				utils: {
-					counter: tag.count,
+					counter: tag.nbr,
 					actions: [
 						{
 							icon: 'icon-rename',
 							text: 'Rename',
-							action: () => this.setEditingTag(tag.name, true),
+							action: () => this.setEditingTag(tag.tag, true),
 						},
 						{
 							icon: 'icon-delete',
 							text: 'Delete',
-							action: () => this.onDeleteTag(tag.name),
+							action: () => this.onDeleteTag(tag.tag),
 						},
 					],
 				},

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -37,26 +37,26 @@ export default {
 	computed: {
 		tagMenu() {
 			return this.$store.state.tags.map(tag => ({
-				router: { name: 'tags', params: { tags: tag.tag } },
+				router: { name: 'tags', params: { tags: tag.name } },
 				icon: 'icon-tag',
-				classes: this.editingTag === tag.tag ? ['editing'] : [],
-				text: tag.tag,
+				classes: this.editingTag === tag.name ? ['editing'] : [],
+				text: tag.name,
 				edit: {
-					action: e => this.onRenameTag(tag.tag, e.target.elements[0].value),
-					reset: () => this.setEditingTag(tag.tag, false),
+					action: e => this.onRenameTag(tag.name, e.target.elements[0].value),
+					reset: () => this.setEditingTag(tag.name, false),
 				},
 				utils: {
-					counter: tag.nbr,
+					counter: tag.count,
 					actions: [
 						{
 							icon: 'icon-rename',
 							text: 'Rename',
-							action: () => this.setEditingTag(tag.tag, true),
+							action: () => this.setEditingTag(tag.name, true),
 						},
 						{
 							icon: 'icon-delete',
 							text: 'Delete',
-							action: () => this.onDeleteTag(tag.tag),
+							action: () => this.onDeleteTag(tag.name),
 						},
 					],
 				},

--- a/tests/TagMapperTest.php
+++ b/tests/TagMapperTest.php
@@ -83,10 +83,10 @@ class TagMapperTest extends TestCase {
 		$this->assertContains('four', $allTags);
 
 		$allTagsWithCount = $this->tagMapper->findAllWithCount($this->userId);
-		$this->assertContains(['tag' => 'one', 'nbr' => 3], $allTagsWithCount);
-		$this->assertContains(['tag' => 'two', 'nbr' => 2], $allTagsWithCount);
-		$this->assertContains(['tag' => 'three', 'nbr' => 1], $allTagsWithCount);
-		$this->assertContains(['tag' => 'four', 'nbr' => 1], $allTagsWithCount);
+		$this->assertContains(['name' => 'one', 'count' => 3], $allTagsWithCount);
+		$this->assertContains(['name' => 'two', 'count' => 2], $allTagsWithCount);
+		$this->assertContains(['name' => 'three', 'count' => 1], $allTagsWithCount);
+		$this->assertContains(['name' => 'four', 'count' => 1], $allTagsWithCount);
 	}
 
 	/**

--- a/tests/TagMapperTest.php
+++ b/tests/TagMapperTest.php
@@ -101,11 +101,11 @@ class TagMapperTest extends TestCase {
 		$this->assertNotContains('four', $allTags);
 
 		$allTagsWithCount = $this->tagMapper->findAllWithCount($this->userId);
-		$this->assertContains(['tag' => 'one', 'nbr' => 3], $allTagsWithCount);
-		$this->assertContains(['tag' => 'two', 'nbr' => 2], $allTagsWithCount);
-		$this->assertContains(['tag' => 'three', 'nbr' => 1], $allTagsWithCount);
-		$this->assertNotContains(['tag' => 'four', 'nbr' => 1], $allTagsWithCount);
-		$this->assertNotContains(['tag' => 'four', 'nbr' => 0], $allTagsWithCount);
+		$this->assertContains(['name' => 'one', 'count' => 3], $allTagsWithCount);
+		$this->assertContains(['name' => 'two', 'count' => 2], $allTagsWithCount);
+		$this->assertContains(['name' => 'three', 'count' => 1], $allTagsWithCount);
+		$this->assertNotContains(['name' => 'four', 'count' => 1], $allTagsWithCount);
+		$this->assertNotContains(['name' => 'four', 'count' => 0], $allTagsWithCount);
 	}
 
 	/**


### PR DESCRIPTION
The problem we saw was that the tag names and counts weren't showing up. By inspecting the state object, we saw that the tag name and count properties returned from the backend were called `tag` and `nbr`.

Signed-off-by: Graham Lee <leeg@labrary.online>