### PR TITLE
Update error handling on "Import"

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -207,16 +207,12 @@ export default {
 		return axios
 			.post(url(`/bookmark/import`), data)
 			.then(response => {
-				if (!response.ok) {
+				if (!response.data || !response.data.status === 'success') {
 					if (response.status === 413) {
 						throw new Error('Selected file is too large')
 					}
-					throw new Error(response.data.data.join('\n'))
-				} else {
-					const status = response.data.status
-					if (status !== 'success') {
-						throw new Error(response.data)
-					}
+					throw new Error(response.data)
+					console.error('Failed to import bookmarks', response)
 				}
 			})
 			.catch(err => {


### PR DESCRIPTION
The test for `response.ok` doesn't appear to work in latest Brave or Chrome.  The result is that, although the POST to `/import` succeeded, it throws an error with `[Object object] [Object object] ...`.  This test ensures that errors are thrown only when `response.data.success` is not set correctly.  The output of `response.data.data.join('\n')` was worthless in the case of my bug so I wasn't sure which style should be used on actual error scenarios.  Please advise.

![image](https://user-images.githubusercontent.com/127476/74059697-6156e800-499d-11ea-81e6-eb58f4c8c98e.png)
