### PR TITLE
Style fixes / grid view bookmark link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### New
+- In grid view the entire bookmark behaves like a link
+
 ### Fixed
+- Horizontal breadcrumb text alignment
+- Checkbox size in grid view
 - Menu toggle position
-- Breadcrumb text alignment
 
 ## [3.2.1] - 2020-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- Menu toggle position
+- Breadcrumb text alignment
 
 ## [3.2.1] - 2020-06-16
 

--- a/src/components/Bookmark.vue
+++ b/src/components/Bookmark.vue
@@ -182,6 +182,7 @@ export default {
 	background-size: cover !important;
 	background-color: var(--color-main-background);
 	position: relative;
+	padding: 0 8px 0 10px;
 }
 
 .bookmark.active,

--- a/src/components/Bookmark.vue
+++ b/src/components/Bookmark.vue
@@ -11,6 +11,9 @@
 					? `linear-gradient(0deg, var(--color-main-background) 25%, rgba(0, 212, 255, 0) 50%), url('${imageUrl}')`
 					: undefined
 		}">
+		<a
+			:href="url"
+			class="bookmark__click-link" />
 		<template v-if="!renaming">
 			<div v-if="isEditable" class="bookmark__checkbox">
 				<input v-model="selected" class="checkbox" type="checkbox"><label
@@ -286,7 +289,25 @@ export default {
 	margin: 0;
 }
 
+.bookmark--gridview .bookmark__checkbox input[type="checkbox"].checkbox + label::before {
+	margin: 0 3px 3px 3px;
+}
+
 .bookmark--gridview .bookmark__icon {
 	margin: 0 5px 0 10px;
 }
+
+.bookmark__click-link {
+	bottom: 0;
+	display: none;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+}
+
+.bookmark--gridview .bookmark__click-link {
+	display: block;
+}
+
 </style>

--- a/src/components/BookmarksList.vue
+++ b/src/components/BookmarksList.vue
@@ -81,6 +81,9 @@ export default {
 </script>
 <style>
 .bookmarkslist {
+	/* 50px header; 50px breadcrumbs */
+	height: calc(100vh - 50px - 50px);
+	overflow-y: scroll;
 	position: relative;
 }
 

--- a/src/components/BookmarksList.vue
+++ b/src/components/BookmarksList.vue
@@ -83,6 +83,7 @@ export default {
 .bookmarkslist {
 	position: relative;
 }
+
 .bookmarkslist
 	> *:first-child:not(.bookmarkslist__loading):not(.bookmarkslist__empty) {
 	border-top: 1px solid var(--color-border);
@@ -101,6 +102,8 @@ export default {
 .bookmarkslist--gridview {
 	display: flex;
 	flex-flow: wrap;
+	gap: 10px;
+	padding: 0 10px;
 }
 
 .folder--gridview,
@@ -113,7 +116,6 @@ export default {
 	height: 200px;
 	align-items: flex-end;
 	background: var(--color-main-background);
-	margin: 10px 0 0 10px;
 	border: 1px solid var(--color-border);
 	box-shadow: #efefef7d 0px 0 13px 0px inset;
 	border-radius: var(--border-radius);

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -199,24 +199,24 @@ export default {
 </script>
 <style>
 .breadcrumbs {
-	padding: 2px 8px;
+	padding: 0 8px 0 44px;
 	display: flex;
 	position: fixed;
 	z-index: 100;
 	background: var(--color-main-background-translucent);
+	left: 0;
 	right: 0;
-	left: 300px;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (min-width: 768px) {
 	.breadcrumbs {
-		padding-left: 52px;
+		left: 300px;
+		transition: left var(--animation-quick);
+	}
+
+	.app-navigation--close + .app-content .breadcrumbs {
 		left: 0;
 	}
-}
-.breadcrumbs.wide {
-	padding: 2px 8px;
-	left: 0;
 }
 
 .breadcrumbs + * {
@@ -232,7 +232,7 @@ export default {
 .breadcrumbs__path > * {
 	display: inline-block;
 	height: 30px;
-	padding: 7px;
+	padding: 5px 7px;
 	flex-shrink: 0;
 }
 

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -201,22 +201,12 @@ export default {
 .breadcrumbs {
 	padding: 0 8px 0 44px;
 	display: flex;
-	position: fixed;
+	position: absolute;
 	z-index: 100;
 	background: var(--color-main-background-translucent);
 	left: 0;
 	right: 0;
-}
-
-@media only screen and (min-width: 768px) {
-	.breadcrumbs {
-		left: 300px;
-		transition: left var(--animation-quick);
-	}
-
-	.app-navigation--close + .app-content .breadcrumbs {
-		left: 0;
-	}
+	top: 0;
 }
 
 .breadcrumbs + * {

--- a/src/components/Folder.vue
+++ b/src/components/Folder.vue
@@ -159,6 +159,7 @@ export default {
 	display: flex;
 	align-items: center;
 	position: relative;
+	padding: 0 8px 0 10px;
 }
 
 .folder.active,


### PR DESCRIPTION
* Fix the menu toggle position
* Fix some pixel misalignment in the breadcrumb bar
* Makes the entire bookmark behave like a link in grid view
* Tested on desktop and mobile
* Tested with Nextcloud 19 and 20

- closes #1080
- closes #1082 

![image](https://user-images.githubusercontent.com/6216686/85118157-3c626380-b220-11ea-9166-4289e3eede12.png)
