### PR TITLE
remove png extension from filename passed to pageres

### DIFF
--- a/lib/Service/Previewers/PageresBookmarkPreviewer.php
+++ b/lib/Service/Previewers/PageresBookmarkPreviewer.php
@@ -61,7 +61,7 @@ class PageresBookmarkPreviewer implements IBookmarkPreviewer {
 	protected function fetchImage(string $serverPath, string $url): ?Image {
 		$tempPath = $this->tempManager->getTemporaryFile('.png');
 		$tempDir = dirname($tempPath);
-		$tempFile = basename($tempPath);
+		$tempFile = basename($tempPath, '.png');
 		$command = $serverPath;
 		$escapedUrl = escapeshellarg($url);
 


### PR DESCRIPTION
the argument for --filename must not contain the file extension as this one is only a template. without that change a file is created that contain .png.png at the end and so it does not match anymore the $tempPath variable, means the file is generated but can not be found by the following code