### PR TITLE
Fix hidden by search card detail

### DIFF
--- a/src/components/BookmarkContent.vue
+++ b/src/components/BookmarkContent.vue
@@ -73,7 +73,7 @@ export default {
 	right: max( min(27vw, 500px), 300px); /* side bar */
 	bottom: 0;
 	background: var(--color-main-background);
-	z-index: 3000;
+	z-index: 1999;
 	display: flex;
 	overflow: scroll;
 	flex-direction: column;


### PR DESCRIPTION
Now card detail does not overlap the search dialog.

Example:

![1book](https://user-images.githubusercontent.com/48186405/133652203-90ad8612-0cfb-450a-a831-feafb7db832d.png)

---


Closes: https://github.com/nextcloud/bookmarks/issues/1633

Signed-off-by: Eduard Stromenko <estromenko@mail.ru>