### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/command-rebase.yml
+++ b/.github/workflows/command-rebase.yml
@@ -9,8 +9,13 @@ on:
   issue_comment:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   rebase:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
 
     # On pull requests and if the comment starts with `/rebase`

--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -11,8 +11,13 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   auto-approve-merge:
+    permissions:
+      pull-requests: write  # for hmarr/auto-approve-action to approve PRs
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/floccus.yml
+++ b/.github/workflows/floccus.yml
@@ -10,6 +10,9 @@ on:
 env:
   APP_NAME: bookmarks
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,6 +10,9 @@ on:
 env:
   APP_NAME: bookmarks
 
+permissions:
+  contents: read
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -6,6 +6,9 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   static-psalm-analysis:
 

--- a/.github/workflows/repair.yml
+++ b/.github/workflows/repair.yml
@@ -10,6 +10,9 @@ on:
 env:
   APP_NAME: bookmarks
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -10,6 +10,9 @@ on:
 env:
   APP_NAME: bookmarks
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
