### PR TITLE
Fix for "Trying to access array offset on value of type int"

### DIFF
--- a/lib/Db/BookmarkMapper.php
+++ b/lib/Db/BookmarkMapper.php
@@ -270,7 +270,7 @@ class BookmarkMapper extends QBMapper {
 			->from('bookmarks', 'b')
 			->where($qb->expr()->eq('b.user_id', $qb->createPositionalParameter($userId)));
 
-		$count = $qb->execute()->fetch(PDO::FETCH_COLUMN)[0];
+		$count = $qb->execute()->fetch(PDO::FETCH_COLUMN);
 
 		return (int)$count;
 	}


### PR DESCRIPTION
Every time when my nextcloud cron job is running I get the following error log

{"reqId":"xxxx","level":3,"time":"2022-07-28T08:14:41+00:00","remoteAddr":"","user":"hhees","app":"PHP","method":"","url":"--","message":"Trying to access array offset on value of type int at /dataDisk/htdocs/nextcloud-24.0.3/apps/bookmarks/lib/Db/BookmarkMapper.php#273","userAgent":"--","version":"24.0.3.2","exception":{"Exception":"Error","Message":"Trying to access array offset on value of type int at /dataDisk/htdocs/nextcloud-24.0.3/apps/bookmarks/lib/Db/BookmarkMapper.php#273","Code":0,"Trace":[{"file":"/dataDisk/htdocs/nextcloud-24.0.3/apps/bookmarks/lib/Db/BookmarkMapper.php","line":273,"function":"onError","class":"OC\\Log\\ErrorHandler","type":"::"},{"file":"/dataDisk/htdocs/nextcloud-24.0.3/apps/bookmarks/lib/Service/NotesService.php","line":49,"function":"countAll","class":"OCA\\Bookmarks\\Db\\BookmarkMapper","type":"->"},{"file":"/dataDisk/htdocs/nextcloud-24.0.3/apps/bookmarks/lib/BackgroundJobs/ExtractFromNotesJob.php","line":63,"function":"extractBookmarksFromNotes","class":"OCA\\Bookmarks\\Service\\NotesService","type":"->"},{"file":"/dataDisk/htdocs/nextcloud-24.0.3/lib/public/BackgroundJob/Job.php","line":79,"function":"run","class":"OCA\\Bookmarks\\BackgroundJobs\\ExtractFromNotesJob","type":"->"},{"file":"/dataDisk/htdocs/nextcloud-24.0.3/lib/public/BackgroundJob/TimedJob.php","line":95,"function":"execute","class":"OCP\\BackgroundJob\\Job","type":"->"},{"file":"/dataDisk/htdocs/nextcloud-24.0.3/cron.php","line":151,"function":"execute","class":"OCP\\BackgroundJob\\TimedJob","type":"->"}],"File":"/dataDisk/htdocs/nextcloud-24.0.3/lib/private/Log/ErrorHandler.php","Line":92,"CustomMessage":"--"}}

I'm running Nextcloud 24.0.3 with php 8.1.8

The error happens since my last bookmark app update to version 11.0.0