### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/Folder.vue
+++ b/src/components/Folder.vue
@@ -280,6 +280,6 @@ export default {
 	border-radius: var(--border-radius-pill);
 	padding: 5px 10px;
 	margin-right: 3px;
-	background-color: var(--color-primary-light);
+	background-color: var(--color-primary-element-light);
 }
 </style>

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -266,7 +266,7 @@ export default {
 }
 
 .item.dropTarget--available {
-	background: var(--color-primary-light);
+	background: var(--color-primary-element-light);
 }
 
 .item.dropTarget--active {

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -219,7 +219,7 @@ export default {
 <style>
 
 .navigation .dropTarget--available {
-	background: var(--color-primary-light);
+	background: var(--color-primary-element-light);
 }
 
 .navigation .dropTarget--active {

--- a/src/components/SidebarFolder.vue
+++ b/src/components/SidebarFolder.vue
@@ -306,7 +306,7 @@ export default {
 	}
 
 	.share__avatar.active {
-		background-color: var(--color-primary-light);
+		background-color: var(--color-primary-element-light);
 		border-radius: 44px;
 	}
 

--- a/src/mixins/AppGlobal.js
+++ b/src/mixins/AppGlobal.js
@@ -20,7 +20,7 @@ export default {
 			return getComputedStyle(document.documentElement).getPropertyValue('--color-primary-element')
 		},
 		colorPrimaryText() {
-			return getComputedStyle(document.documentElement).getPropertyValue('--color-primary-text')
+			return getComputedStyle(document.documentElement).getPropertyValue('--color-primary-element-text')
 		},
 		colorMainText() {
 			return getComputedStyle(document.documentElement).getPropertyValue('--color-main-text')


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.