### PR TITLE
feat(previews): use secure version of screeenly

### DIFF
--- a/lib/Service/Previewers/ScreeenlyBookmarkPreviewer.php
+++ b/lib/Service/Previewers/ScreeenlyBookmarkPreviewer.php
@@ -52,7 +52,7 @@ class ScreeenlyBookmarkPreviewer implements IBookmarkPreviewer {
 	private $apiUrl;
 
 	public function __construct(IConfig $config, IClientService $clientService, LoggerInterface $logger) {
-		$this->apiUrl = $config->getAppValue('bookmarks', 'previews.screenly.url', 'http://screeenly.com/api/v1/fullsize');
+		$this->apiUrl = $config->getAppValue('bookmarks', 'previews.screenly.url', 'https://secure.screeenly.com/api/v1/fullsize');
 		$this->apiKey = $config->getAppValue('bookmarks', 'previews.screenly.token', '');
 		$this->client = $clientService->newClient();
 		$this->logger = $logger;


### PR DESCRIPTION
Hi there 👋 

Maintainer/host of screeenly.com here. This PR changes the default API URL used by the `ScreeenlyBookmarkPreviewer` to use the version of screeenly that is secured with a SSL certificate.

This version has been available for years, but has never really been documented. To prevent breaking changes, the default domain (screeenly.com) has never been issued a SSL certificate.
The app on secure.screeenly.com is exactly the same as on screeenly.com. User with existing tokens can switch to this version without rotating their API tokens.

The non-secure version of screeenly is being deprecated in the next few months. I will inform users of the app directly once I've decided on an exact date.