### PR TITLE
fix BookmarkPreviewer to not store null values in cache overzealously

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -78,9 +78,9 @@ class AdminController extends Controller {
 		if (!isset($this->previewers[$previewer])) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
-		$previewer = $this->previewers[$previewer];
+		$previewerImp = $this->previewers[$previewer];
 		$test = new Bookmark();
 		$test->setUrl('https://nextcloud.com/');
-		return new Http\DataDisplayResponse($previewer->getImage($test)?->getData() ?? '');
+		return new Http\DataDisplayResponse($previewerImp->getImage($test)?->getData() ?? '');
 	}
 }

--- a/lib/Service/BookmarkPreviewer.php
+++ b/lib/Service/BookmarkPreviewer.php
@@ -99,12 +99,14 @@ class BookmarkPreviewer implements IBookmarkPreviewer {
 			} catch (NotFoundException $e) {
 			} catch (NotPermittedException $e) {
 			}
+			if ($cacheOnly) {
+				continue;
+			}
 			$image = $previewer->getImage($bookmark, $cacheOnly);
 			if (isset($image)) {
 				$this->cache->set($key, $image->serialize(), self::CACHE_TTL);
 				return $image;
 			}
-
 			$this->cache->set($key, 'null', self::CACHE_TTL);
 		}
 


### PR DESCRIPTION
Signed-off-by: Marcel Klehr <mklehr@gmx.net>