### PR TITLE
use new puppeteer browser env variable

### DIFF
--- a/src/components/ViewAdmin.vue
+++ b/src/components/ViewAdmin.vue
@@ -120,7 +120,7 @@
 			<p>
 				<label>{{ t('bookmarks', 'Pageres ENV variables') }}
 					<input v-model="settings['previews.pageres.env']"
-						placeholder="CHROMIUM_PATH=/usr/bin/chromium-browser PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false"
+						placeholder="PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser"
 						type="text"
 						@input="onChange"></label>
 			</p>


### PR DESCRIPTION
The puppeteer browser environment variable was changed in https://github.com/puppeteer/puppeteer/pull/9440
updated the placeholder in the admin panel

old:
PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser

new:
PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser