### PR TITLE
Add LineBoss Shopify theme scaffold, styles, and build plan docs

### DIFF
--- a/docs/lineboss-shopify-build-plan.md
+++ b/docs/lineboss-shopify-build-plan.md
@@ -1,0 +1,212 @@
+# LineBoss Shopify Store Build Plan (Inspired by Poco Techmart)
+
+This plan outlines how to build a Shopify storefront for an FDM 3D printing filament brand named **LineBoss**, using the visual and merchandising style of the Poco "Techmart" demo as inspiration.
+
+## 1) Foundation Setup
+
+- Create a Shopify account and store (US market defaults).
+- Choose a premium electronics-style theme with:
+  - homepage section stacking (hero, category tiles, featured products),
+  - promotional banners,
+  - built-in product filtering,
+  - mega menu support,
+  - product card badges (new, sale, top seller).
+- Configure core settings:
+  - currency: USD,
+  - units: metric with inch references in product copy,
+  - tax and shipping profiles,
+  - Shopify Markets (US first, optional CA/EU later).
+
+## 2) Brand Identity for LineBoss
+
+### Brand direction
+- **Name:** LineBoss
+- **Category:** Premium FDM filament
+- **Tone:** Technical, reliable, performance-driven
+- **Tagline ideas:**
+  - "Command Every Layer"
+  - "Precision You Can Print"
+  - "Filament That Obeys"
+
+### Visual system
+- Primary colors:
+  - Carbon Black `#111111`
+  - Signal Orange `#FF6A00`
+  - Steel Gray `#6E7781`
+  - White `#FFFFFF`
+- Typography:
+  - Headlines: geometric sans (e.g., Montserrat)
+  - Body: neutral sans (e.g., Inter)
+- Icon style:
+  - Material icons for nozzle temp, bed temp, diameter tolerance, spool weight.
+
+## 3) Catalog Architecture
+
+### Core collections
+- PLA Filament
+- PETG Filament
+- ABS Filament
+- TPU (Flexible)
+- Carbon Fiber Reinforced
+- Silk / Specialty Finishes
+- Multi-Pack Bundles
+- Clearance / Open Box
+
+### Product schema (for each SKU)
+- Material type (PLA, PETG, etc.)
+- Diameter (1.75 mm)
+- Net weight (1 kg / 0.5 kg)
+- Color family
+- Finish (matte, silk, translucent)
+- Print temperature range
+- Bed temperature range
+- Speed profile (normal/high-speed)
+- Drying recommendation
+- Compatibility tags (Bambu, Prusa, Creality, etc.)
+
+### Suggested initial launch SKUs
+- 18–24 PLA colors
+- 8–12 PETG colors
+- 6 ABS colors
+- 6 TPU colors
+- 4 CF-reinforced options
+- 3 curated bundles (starter, prototyping, cosplay)
+
+## 4) Homepage Structure (Poco-like)
+
+1. **Top utility bar**
+   - Free shipping threshold
+   - Support email/chat
+   - "Track Order"
+
+2. **Hero banner carousel**
+   - Slide 1: "LineBoss PLA Pro"
+   - Slide 2: "Engineering PETG"
+   - Slide 3: "TPU Flex Series"
+
+3. **Category icon row**
+   - PLA, PETG, ABS, TPU, CF, Bundles
+
+4. **Featured collections grid**
+   - Top Sellers
+   - New Colors
+   - High Speed Compatible
+   - Creator Picks
+
+5. **Promotion banners**
+   - "Buy 4 Get 1 Mini Sample"
+   - "Starter Bundle - Save 12%"
+
+6. **Best sellers carousel**
+   - Product cards with swatches and quick add
+
+7. **Why LineBoss block**
+   - Tight tolerances
+   - Vacuum-sealed and desiccated
+   - Consistent winding
+   - Layer adhesion confidence
+
+8. **Social proof**
+   - Reviews with printer model context
+
+9. **Footer**
+   - Material guide
+   - Print settings library
+   - Wholesale / B2B inquiry
+
+## 5) Navigation & UX
+
+- **Mega menu**
+  - Shop by Material
+  - Shop by Application (functional parts, cosplay, decor)
+  - Shop by Printer Brand
+  - Resources (temperature chart, drying guide)
+- **Filters on collection pages**
+  - Material, Color, Finish, Weight, Price, Availability
+- **Search boosts**
+  - Prioritize exact material/color matches
+- **Sticky add-to-cart** on product pages for mobile.
+
+## 6) Product Page Blueprint
+
+- Gallery: spool image + printed sample + closeup texture.
+- Quick spec chips:
+  - Nozzle temp,
+  - Bed temp,
+  - Fan recommendation,
+  - Enclosure recommendation.
+- Tabs/accordions:
+  - Description,
+  - Print settings,
+  - Technical data sheet,
+  - Storage & drying,
+  - Shipping & returns.
+- Upsells:
+  - matching colors,
+  - nozzle kits,
+  - dry box accessories.
+
+## 7) Essential Apps / Integrations
+
+- Reviews: Judge.me or Loox
+- Upsell bundles: Rebuy / Frequently Bought Together
+- Email/SMS: Klaviyo
+- Helpdesk/chat: Gorgias or Shopify Inbox
+- Subscriptions (optional): Recharge / Skio for monthly filament plans
+- Analytics: GA4 + Meta Pixel + TikTok Pixel (if used)
+
+## 8) Conversion & Trust
+
+- Clear shipping policy (lead times by region).
+- Moisture-safe packaging promise.
+- 30-day satisfaction policy on unopened spools.
+- FAQ covering:
+  - stringing,
+  - warping,
+  - moisture issues,
+  - profile starting points.
+
+## 9) Launch Content Checklist
+
+- Homepage banners (desktop + mobile)
+- Collection hero images by material
+- 5+ images per product
+- 1 comparison chart (PLA vs PETG vs ABS vs TPU)
+- 3 educational blog posts:
+  1. "Best filament for beginners"
+  2. "How humidity affects print quality"
+  3. "Choosing filament by use case"
+
+## 10) 30-Day Execution Roadmap
+
+### Week 1
+- Finalize branding, theme, navigation, and collection model.
+- Build homepage skeleton and menu.
+
+### Week 2
+- Upload products, metafields, images, and filtering logic.
+- Configure checkout, shipping, taxes, and legal pages.
+
+### Week 3
+- Install apps, automate email flows, and QA mobile UX.
+- Collect initial review content from seed customers.
+
+### Week 4
+- Launch paid + organic campaigns.
+- Run A/B test on hero copy and bundle promo.
+- Review conversion funnel and optimize collection pages.
+
+## 11) KPI Targets (First 90 Days)
+
+- Conversion rate: 2.0–3.5%
+- AOV: $45–$70
+- Returning customer rate: 20%+
+- Email revenue share: 20–30%
+
+## 12) Immediate Next Steps
+
+1. Purchase domain and connect to Shopify.
+2. Select theme and create a LineBoss style preset.
+3. Prepare first 30–40 SKUs with complete technical specs.
+4. Produce homepage banners and product photo set.
+5. Soft launch to a limited audience for feedback.

--- a/shopify/lineboss/assets/lineboss.css
+++ b/shopify/lineboss/assets/lineboss.css
@@ -1,0 +1,290 @@
+:root {
+  --lb-bg: #ffffff;
+  --lb-text: #111111;
+  --lb-muted: #6e7781;
+  --lb-accent: #ff6a00;
+  --lb-panel: #f5f7fa;
+  --lb-border: #e4e8ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--lb-text);
+  background: var(--lb-bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page-width {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.lb-topbar {
+  background: var(--lb-text);
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.lb-header__inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--lb-border);
+}
+
+.lb-logo {
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.lb-nav ul {
+  display: flex;
+  gap: 1.2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  justify-content: center;
+}
+
+.lb-header__actions {
+  display: flex;
+  gap: 0.85rem;
+  font-size: 0.95rem;
+}
+
+.lb-main,
+.lineboss-main {
+  display: block;
+}
+
+.lb-hero {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 1.25rem;
+  margin-block: 1.5rem;
+}
+
+.lb-hero__content {
+  background: var(--lb-panel);
+  border: 1px solid var(--lb-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.lb-eyebrow {
+  text-transform: uppercase;
+  color: var(--lb-accent);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+}
+
+.lb-btn {
+  display: inline-block;
+  background: var(--lb-accent);
+  color: #fff;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.lb-hero__slides {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.lb-slide {
+  position: relative;
+  min-height: 200px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--lb-border);
+}
+
+.lb-slide img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.lb-slide__overlay {
+  position: absolute;
+  inset: auto 0 0;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
+  color: #fff;
+  padding: 1rem;
+}
+
+.lb-section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.8rem;
+}
+
+.lb-category-grid,
+.lb-product-grid,
+.lb-promo-grid,
+.lb-value-grid,
+.lb-footer__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.lb-category-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.lb-category {
+  border: 1px solid var(--lb-border);
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.lb-featured,
+.lb-promos,
+.lb-value,
+.lb-categories {
+  margin-block: 2rem;
+}
+
+.lb-product-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.lb-product-card {
+  border: 1px solid var(--lb-border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.lb-product-card__image,
+.lb-product-card__media {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  display: block;
+  background: var(--lb-panel);
+}
+
+.lb-product-card__body {
+  padding: 0.9rem;
+}
+
+.lb-price--sale {
+  color: var(--lb-accent);
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+.lb-promo-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.lb-promo {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--lb-border);
+  background: var(--lb-panel);
+}
+
+.lb-promo img {
+  width: 100%;
+  display: block;
+}
+
+.lb-promo__content,
+.lb-value-item {
+  padding: 1rem;
+}
+
+.lb-value-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.lb-value-item {
+  border: 1px solid var(--lb-border);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.lb-footer {
+  background: #0e1218;
+  color: #d9e0ea;
+  margin-top: 3rem;
+  padding: 2rem 0;
+}
+
+.lb-footer__grid {
+  grid-template-columns: 2fr 1fr 1fr;
+}
+
+.lb-footer h3,
+.lb-footer h4 {
+  color: #fff;
+  margin-top: 0;
+}
+
+.lb-footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+@media (max-width: 1024px) {
+  .lb-product-grid,
+  .lb-category-grid,
+  .lb-value-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lb-hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .lb-header__inner {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .lb-nav ul {
+    overflow-x: auto;
+    justify-content: flex-start;
+    padding-bottom: 0.5rem;
+  }
+
+  .lb-product-grid,
+  .lb-category-grid,
+  .lb-promo-grid,
+  .lb-value-grid,
+  .lb-footer__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/shopify/lineboss/layout/theme.liquid
+++ b/shopify/lineboss/layout/theme.liquid
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="{{ request.locale.iso_code }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="#111111">
+    <link rel="canonical" href="{{ canonical_url }}">
+
+    {%- if settings.favicon != blank -%}
+      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 96, height: 96 }}">
+    {%- endif -%}
+
+    <title>
+      {{ page_title }}
+      {%- if current_tags %} &ndash; {{ 'general.meta.tags' | t: tags: current_tags | default: current_tags | join: ', ' }}{% endif -%}
+      {%- if current_page != 1 %} &ndash; {{ 'general.meta.page' | t: page: current_page | default: current_page }}{% endif -%}
+      {%- unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless -%}
+    </title>
+
+    {{ content_for_header }}
+    {{ 'lineboss.css' | asset_url | stylesheet_tag }}
+  </head>
+  <body>
+    <a class="skip-link" href="#MainContent">Skip to content</a>
+
+    {% section 'header' %}
+
+    <main id="MainContent" class="lineboss-main" role="main">
+      {{ content_for_layout }}
+    </main>
+
+    {% section 'footer' %}
+  </body>
+</html>

--- a/shopify/lineboss/sections/category-grid.liquid
+++ b/shopify/lineboss/sections/category-grid.liquid
@@ -1,0 +1,67 @@
+<section class="lb-categories page-width">
+  <div class="lb-section-heading">
+    <h2>{{ section.settings.heading }}</h2>
+  </div>
+
+  <div class="lb-category-grid">
+    {% for block in section.blocks %}
+      {% assign category_collection = block.settings.collection %}
+      <a class="lb-category" href="{{ category_collection.url | default: '#' }}" {{ block.shopify_attributes }}>
+        {% if block.settings.icon != blank %}
+          {{ block.settings.icon | image_url: width: 120 | image_tag: loading: 'lazy', alt: block.settings.label }}
+        {% endif %}
+        <span>{{ block.settings.label }}</span>
+      </a>
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "LineBoss Category Grid",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Shop by Material"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "category",
+      "name": "Category",
+      "settings": [
+        {
+          "type": "text",
+          "id": "label",
+          "label": "Label",
+          "default": "PLA"
+        },
+        {
+          "type": "collection",
+          "id": "collection",
+          "label": "Collection"
+        },
+        {
+          "type": "image_picker",
+          "id": "icon",
+          "label": "Icon"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 8,
+  "presets": [
+    {
+      "name": "LineBoss Category Grid",
+      "blocks": [
+        { "type": "category", "settings": { "label": "PLA" } },
+        { "type": "category", "settings": { "label": "PETG" } },
+        { "type": "category", "settings": { "label": "ABS" } },
+        { "type": "category", "settings": { "label": "TPU" } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/featured-products.liquid
+++ b/shopify/lineboss/sections/featured-products.liquid
@@ -1,0 +1,58 @@
+<section class="lb-featured page-width">
+  <div class="lb-section-heading">
+    <h2>{{ section.settings.heading }}</h2>
+    {% if section.settings.collection != blank %}
+      <a href="{{ section.settings.collection.url }}">View all</a>
+    {% endif %}
+  </div>
+
+  {% assign featured_collection = section.settings.collection %}
+  <div class="lb-product-grid">
+    {% if featured_collection != blank %}
+      {% for product in featured_collection.products limit: section.settings.products_to_show %}
+        {% render 'product-card', product: product %}
+      {% endfor %}
+    {% else %}
+      {% for i in (1..4) %}
+        <article class="lb-product-card lb-product-card--placeholder">
+          <div class="lb-product-card__media"></div>
+          <h3>Sample Filament {{ i }}</h3>
+          <p>Assign a collection in this section to display products.</p>
+        </article>
+      {% endfor %}
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "LineBoss Featured Products",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Top Selling Filament"
+    },
+    {
+      "type": "collection",
+      "id": "collection",
+      "label": "Collection"
+    },
+    {
+      "type": "range",
+      "id": "products_to_show",
+      "label": "Products to show",
+      "min": 4,
+      "max": 12,
+      "step": 1,
+      "default": 8
+    }
+  ],
+  "presets": [
+    {
+      "name": "LineBoss Featured Products"
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/footer.liquid
+++ b/shopify/lineboss/sections/footer.liquid
@@ -1,0 +1,46 @@
+<footer class="lb-footer">
+  <div class="page-width lb-footer__grid">
+    <div>
+      <h3>{{ section.settings.brand_name }}</h3>
+      <p>{{ section.settings.description }}</p>
+    </div>
+
+    <div>
+      <h4>Support</h4>
+      <ul>
+        <li><a href="/pages/shipping-policy">Shipping Policy</a></li>
+        <li><a href="/pages/returns">Returns</a></li>
+        <li><a href="/pages/contact">Contact</a></li>
+      </ul>
+    </div>
+
+    <div>
+      <h4>Resources</h4>
+      <ul>
+        <li><a href="/blogs/news">Print Guides</a></li>
+        <li><a href="/pages/material-guide">Material Guide</a></li>
+        <li><a href="/pages/wholesale">Wholesale</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+{% schema %}
+{
+  "name": "LineBoss Footer",
+  "settings": [
+    {
+      "type": "text",
+      "id": "brand_name",
+      "label": "Brand name",
+      "default": "LineBoss"
+    },
+    {
+      "type": "textarea",
+      "id": "description",
+      "label": "Description",
+      "default": "Precision filament for FDM makers who need consistent quality from first layer to final part."
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/header.liquid
+++ b/shopify/lineboss/sections/header.liquid
@@ -1,0 +1,60 @@
+<header class="lb-header">
+  <div class="lb-topbar">
+    <p>{{ section.settings.announcement_text }}</p>
+  </div>
+
+  <div class="lb-header__inner page-width">
+    <a href="{{ routes.root_url }}" class="lb-logo" aria-label="{{ shop.name }}">
+      {% if section.settings.logo != blank %}
+        {{ section.settings.logo | image_url: width: 240 | image_tag: alt: shop.name }}
+      {% else %}
+        <span>{{ section.settings.brand_name }}</span>
+      {% endif %}
+    </a>
+
+    <nav class="lb-nav" aria-label="Main navigation">
+      <ul>
+        {% for link in section.settings.menu.links %}
+          <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+
+    <div class="lb-header__actions">
+      <a href="{{ routes.search_url }}" aria-label="Search">Search</a>
+      <a href="{{ routes.account_url }}" aria-label="Account">Account</a>
+      <a href="{{ routes.cart_url }}" aria-label="Cart">Cart ({{ cart.item_count }})</a>
+    </div>
+  </div>
+</header>
+
+{% schema %}
+{
+  "name": "LineBoss Header",
+  "settings": [
+    {
+      "type": "text",
+      "id": "announcement_text",
+      "label": "Announcement bar text",
+      "default": "Free U.S. shipping on filament orders over $49"
+    },
+    {
+      "type": "text",
+      "id": "brand_name",
+      "label": "Fallback brand name",
+      "default": "LineBoss"
+    },
+    {
+      "type": "image_picker",
+      "id": "logo",
+      "label": "Logo"
+    },
+    {
+      "type": "link_list",
+      "id": "menu",
+      "label": "Navigation menu",
+      "default": "main-menu"
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/hero.liquid
+++ b/shopify/lineboss/sections/hero.liquid
@@ -1,0 +1,113 @@
+<section class="lb-hero page-width">
+  <div class="lb-hero__content">
+    <p class="lb-eyebrow">{{ section.settings.eyebrow }}</p>
+    <h1>{{ section.settings.heading }}</h1>
+    <p>{{ section.settings.subheading }}</p>
+    <a class="lb-btn" href="{{ section.settings.primary_cta_link }}">{{ section.settings.primary_cta_text }}</a>
+  </div>
+
+  <div class="lb-hero__slides">
+    {% for block in section.blocks %}
+      <article class="lb-slide" {{ block.shopify_attributes }}>
+        {% if block.settings.image != blank %}
+          {{ block.settings.image | image_url: width: 900 | image_tag: loading: 'lazy', alt: block.settings.title }}
+        {% endif %}
+        <div class="lb-slide__overlay">
+          <h3>{{ block.settings.title }}</h3>
+          <p>{{ block.settings.copy }}</p>
+          <a href="{{ block.settings.link }}">{{ block.settings.link_text }}</a>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "LineBoss Hero",
+  "settings": [
+    {
+      "type": "text",
+      "id": "eyebrow",
+      "label": "Eyebrow",
+      "default": "Engineered FDM Filament"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Command Every Layer with LineBoss"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Premium PLA, PETG, ABS, and TPU filament tuned for consistent extrusion, clean winding, and stronger parts."
+    },
+    {
+      "type": "text",
+      "id": "primary_cta_text",
+      "label": "Primary CTA text",
+      "default": "Shop Filament"
+    },
+    {
+      "type": "url",
+      "id": "primary_cta_link",
+      "label": "Primary CTA link"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Slide image"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "PLA Pro Series"
+        },
+        {
+          "type": "textarea",
+          "id": "copy",
+          "label": "Description",
+          "default": "Reliable flow, low odor, and beautiful surface finish for daily prints."
+        },
+        {
+          "type": "text",
+          "id": "link_text",
+          "label": "Link text",
+          "default": "Explore"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "Link"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 4,
+  "presets": [
+    {
+      "name": "LineBoss Hero",
+      "blocks": [
+        {
+          "type": "slide"
+        },
+        {
+          "type": "slide"
+        },
+        {
+          "type": "slide"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/promo-banners.liquid
+++ b/shopify/lineboss/sections/promo-banners.liquid
@@ -1,0 +1,68 @@
+<section class="lb-promos page-width">
+  <div class="lb-promo-grid">
+    {% for block in section.blocks %}
+      <article class="lb-promo" {{ block.shopify_attributes }}>
+        {% if block.settings.image != blank %}
+          {{ block.settings.image | image_url: width: 720 | image_tag: loading: 'lazy', alt: block.settings.heading }}
+        {% endif %}
+        <div class="lb-promo__content">
+          <h3>{{ block.settings.heading }}</h3>
+          <p>{{ block.settings.copy }}</p>
+          <a href="{{ block.settings.link }}">{{ block.settings.link_text }}</a>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "LineBoss Promo Banners",
+  "blocks": [
+    {
+      "type": "promo",
+      "name": "Promo",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
+        },
+        {
+          "type": "text",
+          "id": "heading",
+          "label": "Heading",
+          "default": "Bundle Savings"
+        },
+        {
+          "type": "textarea",
+          "id": "copy",
+          "label": "Copy",
+          "default": "Buy 4 spools and get a sample mini spool for testing new colorways."
+        },
+        {
+          "type": "text",
+          "id": "link_text",
+          "label": "Link text",
+          "default": "Shop Bundles"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "Link"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 3,
+  "presets": [
+    {
+      "name": "LineBoss Promo Banners",
+      "blocks": [
+        { "type": "promo" },
+        { "type": "promo" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/sections/value-props.liquid
+++ b/shopify/lineboss/sections/value-props.liquid
@@ -1,0 +1,60 @@
+<section class="lb-value page-width">
+  <div class="lb-section-heading">
+    <h2>{{ section.settings.heading }}</h2>
+  </div>
+
+  <div class="lb-value-grid">
+    {% for block in section.blocks %}
+      <article class="lb-value-item" {{ block.shopify_attributes }}>
+        <h3>{{ block.settings.title }}</h3>
+        <p>{{ block.settings.description }}</p>
+      </article>
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "LineBoss Value Props",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Why Makers Choose LineBoss"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "item",
+      "name": "Value item",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title",
+          "default": "Tight Diameter Tolerance"
+        },
+        {
+          "type": "textarea",
+          "id": "description",
+          "label": "Description",
+          "default": "Smooth feeding and reliable extrusion help reduce failed prints and surface artifacts."
+        }
+      ]
+    }
+  ],
+  "max_blocks": 4,
+  "presets": [
+    {
+      "name": "LineBoss Value Props",
+      "blocks": [
+        { "type": "item" },
+        { "type": "item", "settings": { "title": "Vacuum-Sealed Packaging" } },
+        { "type": "item", "settings": { "title": "Consistent Winding" } },
+        { "type": "item", "settings": { "title": "Creator-Tested Colors" } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/shopify/lineboss/snippets/product-card.liquid
+++ b/shopify/lineboss/snippets/product-card.liquid
@@ -1,0 +1,31 @@
+<article class="lb-product-card">
+  <a href="{{ product.url }}" class="lb-product-card__media-link">
+    {% if product.featured_image %}
+      {{ product.featured_image | image_url: width: 600 | image_tag: loading: 'lazy', alt: product.title, class: 'lb-product-card__image' }}
+    {% else %}
+      <div class="lb-product-card__media"></div>
+    {% endif %}
+  </a>
+
+  <div class="lb-product-card__body">
+    <h3><a href="{{ product.url }}">{{ product.title }}</a></h3>
+
+    <p class="lb-product-card__price">
+      {% if product.compare_at_price > product.price %}
+        <span class="lb-price--sale">{{ product.price | money }}</span>
+        <s>{{ product.compare_at_price | money }}</s>
+      {% else %}
+        <span>{{ product.price | money }}</span>
+      {% endif %}
+    </p>
+
+    {% if product.available %}
+      <form method="post" action="/cart/add">
+        <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+        <button class="lb-btn" type="submit">Add to cart</button>
+      </form>
+    {% else %}
+      <p class="lb-soldout">Sold out</p>
+    {% endif %}
+  </div>
+</article>

--- a/shopify/lineboss/templates/index.liquid
+++ b/shopify/lineboss/templates/index.liquid
@@ -1,0 +1,5 @@
+{% section 'hero' %}
+{% section 'category-grid' %}
+{% section 'featured-products' %}
+{% section 'promo-banners' %}
+{% section 'value-props' %}


### PR DESCRIPTION
### Motivation
- Provide a lightweight Shopify storefront scaffold and design system for a filament brand called `LineBoss`, inspired by the Poco "Techmart" demo. 
- Create reusable sections and components to assemble a marketing-focused homepage and product catalog quickly. 

### Description
- Add a high-level storefront build plan document at `docs/lineboss-shopify-build-plan.md` describing brand direction, catalog model, homepage layout, launch checklist, and a 30-day roadmap. 
- Introduce a new `shopify/lineboss` theme scaffold including `layout/theme.liquid`, `templates/index.liquid`, section files `hero`, `category-grid`, `featured-products`, `promo-banners`, `value-props`, `header`, and `footer`, and the `snippets/product-card.liquid` component. 
- Add `shopify/lineboss/assets/lineboss.css` implementing CSS variables, responsive grids, component styles, and utility classes used by the new sections. 
- Define section `schema` blocks for easy customization of content and collections via the Shopify theme editor. 

### Testing
- No automated tests were run as part of this change; the delivery is a static theme scaffold and documentation intended for manual review and in-theme QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d98714bc00832e9c6808fafc85390d)