### PR TITLE
CrawlService: Update UA_FIREFOX const to recent version

### DIFF
--- a/lib/Service/CrawlService.php
+++ b/lib/Service/CrawlService.php
@@ -34,7 +34,7 @@ class CrawlService {
 	public const TIMEOUT = 60;
 	public const CONNECT_TIMEOUT = 30;
 	public const READ_TIMEOUT = 30;
-	public const UA_FIREFOX = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0';
+	public const UA_FIREFOX = 'Mozilla/5.0 (X11; Linux x86_64; rv:150.0) Gecko/20100101 Firefox/150.0';
 
 	private MimeTypes $mimey;
 


### PR DESCRIPTION
Hasn't been updated since back then in 2021 with #1518 so just bumping to a more recent version. Could also help as some sites may even block/reject such outdated versions.

Also dropped Ubuntu, Firefox is not sending this anymore since quite some time and probably not really required as well.