### PR TITLE
Fix Nextcloud 34 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Requirements:
 		<database>pgsql</database>
 		<lib>intl</lib>
 		<lib>mbstring</lib>
-		<nextcloud min-version="32" max-version="33" />
+		<nextcloud min-version="32" max-version="34" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Bookmarks\BackgroundJobs\CrawlJob</job>

--- a/lib/AugmentedTemplateResponse.php
+++ b/lib/AugmentedTemplateResponse.php
@@ -8,8 +8,8 @@
 
 namespace OCA\Bookmarks;
 
-use OC;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IURLGenerator;
 
 /**
  * @template S of \OCP\AppFramework\Http::STATUS_*
@@ -19,7 +19,11 @@ use OCP\AppFramework\Http\TemplateResponse;
 class AugmentedTemplateResponse extends TemplateResponse {
 	public function render() {
 		$return = parent::render();
-		preg_replace('/<link rel="manifest" href="(.*?)">/i', '<link rel="manifest" href="' . OC::$server->getURLGenerator()->linkToRouteAbsolute('bookmarks.web_view.manifest') . '">', $return);
+		$params = $this->getParams();
+		if (isset($params['url']) && $params['url'] instanceof IURLGenerator) {
+			$manifestUrl = $params['url']->linkToRouteAbsolute('bookmarks.web_view.manifest');
+			$return = preg_replace('/<link rel="manifest" href="(.*?)">/i', '<link rel="manifest" href="' . $manifestUrl . '">', $return);
+		}
 		return $return;
 	}
 }

--- a/lib/ExportResponse.php
+++ b/lib/ExportResponse.php
@@ -8,11 +8,11 @@
 
 namespace OCA\Bookmarks;
 
-use OC;
 use OC\HintException;
 use OCA\Theming\ThemingDefaults;
 use OCP\AppFramework\Http\Response;
 use OCP\IDateTimeFormatter;
+use OCP\IUserSession;
 
 /**
  * @psalm-template S of int
@@ -25,7 +25,7 @@ class ExportResponse extends Response {
 	public function __construct($returnstring) {
 		parent::__construct();
 
-		$user = OC::$server->getUserSession()->getUser();
+		$user = \OCP\Server::get(IUserSession::class)->getUser();
 		if (is_null($user)) {
 			throw new HintException('User not logged in');
 		}


### PR DESCRIPTION
Nextcloud 34 removed the deprecated convenience getters on `OC\Server`, which caused the following error when switching to the bookmarks app:
 
> Error: Call to undefined method OC\Server::getURLGenerator()

Likewise, exporting bookmarks caused the following error:

> Exception: Call to undefined method OC\Server::getUserSession()
 
This edit replaces the removed getters with public `OCP` APIs and bumps the
supported version range. As far as I can tell this was the only incompatibility with Nextcloud 34.

Fixes #2437