### PR TITLE
fix(AugmentedTemplateResponse): fix manifest route name and return replacement

### DIFF
--- a/lib/AugmentedTemplateResponse.php
+++ b/lib/AugmentedTemplateResponse.php
@@ -19,7 +19,7 @@ use OCP\IURLGenerator;
 class AugmentedTemplateResponse extends TemplateResponse {
 	public function render() {
 		$return = parent::render();
-		preg_replace('/<link rel="manifest" href="(.*?)">/i', '<link rel="manifest" href="' . \OCP\Server::get(IUrlGenerator::class)->linkToRouteAbsolute('bookmarks.web_view.manifest') . '">', $return);
+		$return = preg_replace('/<link rel="manifest" href="(.*?)">/i', '<link rel="manifest" href="' . \OCP\Server::get(IUrlGenerator::class)->linkToRouteAbsolute('bookmarks.webview.manifest') . '">', $return);
 		return $return;
 	}
 }

--- a/tests/AugmentedTemplateResponseTest.php
+++ b/tests/AugmentedTemplateResponseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Copyright (c) 2026. The Nextcloud Bookmarks contributors.
+ *
+ * This file is licensed under the Affero General Public License version 3 or later. See the COPYING file.
+ */
+
+namespace OCA\Bookmarks\Tests;
+
+use OCA\Bookmarks\AugmentedTemplateResponse;
+use OCP\IURLGenerator;
+
+class AugmentedTemplateResponseTest extends TestCase {
+	public function testRouteExists(): void {
+		$urlGenerator = \OCP\Server::get(IURLGenerator::class);
+		$url = $urlGenerator->linkToRouteAbsolute('bookmarks.webview.manifest');
+		$this->assertNotEmpty($url);
+		$this->assertStringContainsString('manifest.webmanifest', $url);
+	}
+}


### PR DESCRIPTION
## What
Fix the route name used for manifest generation in Nextcloud 32 to bookmarks.webview.manifest, and assign the result of preg_replace back to $return so the replacement is not discarded.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #2467