### PR TITLE
fix: correct spelling errors in comments and docstrings

### DIFF
--- a/lib/Controller/InternalBookmarkController.php
+++ b/lib/Controller/InternalBookmarkController.php
@@ -170,7 +170,7 @@ class InternalBookmarkController extends ApiController {
 
 	/**
 	 *
-	 * @param int $id The id of the bookmark whose favicon shoudl be returned
+	 * @param int $id The id of the bookmark whose favicon should be returned
 	 *
 	 * @return Http\DataDisplayResponse|Http\NotFoundResponse|Http\RedirectResponse|Http\DataResponse
 	 *
@@ -184,7 +184,7 @@ class InternalBookmarkController extends ApiController {
 	}
 
 	/**
-	 * @param int $id The id of the bookmark whose image shoudl be returned
+	 * @param int $id The id of the bookmark whose image should be returned
 	 *
 	 * @return Http\DataDisplayResponse|Http\NotFoundResponse|Http\RedirectResponse|Http\DataResponse
 	 *

--- a/lib/Db/BookmarkMapper.php
+++ b/lib/Db/BookmarkMapper.php
@@ -359,7 +359,7 @@ class BookmarkMapper extends QBMapper {
 				->from('*PREFIX*bookmarks_tree', 'tr')
 				->join('tr', 'folder_tree', 'e', 'e.item_id = tr.parent_folder AND e.type = ' . $secondRecursiveCase->createPositionalParameter(TreeMapper::TYPE_FOLDER) . (!$withSoftDeleted ? ' AND e.soft_deleted_at is NULL' : ''));
 
-			// First the base case together with the normal recurisve case
+			// First the base case together with the normal recursive case
 			// Then the second helper base case together with the recursive shares case
 			// then we need another instance of the first recursive case, duplicated here as secondRecursive case
 			// to recurse into child folders of shared folders

--- a/lib/Service/BookmarksParser.php
+++ b/lib/Service/BookmarksParser.php
@@ -250,7 +250,7 @@ class BookmarksParser {
 			if (isset($attributes['add_date'])) {
 				$added = new DateTime();
 				if ((int)$attributes['add_date'] > self::THOUSAND_YEARS) {
-					// Google exports dates in miliseconds. This way we only lose the first year of UNIX Epoch.
+					// Google exports dates in milliseconds. This way we only lose the first year of UNIX Epoch.
 					// This is invalid once we hit 2970. So, quite a long time.
 					$added->setTimestamp(((int)($attributes['add_date']) / 1000));
 				} else {
@@ -266,7 +266,7 @@ class BookmarksParser {
 		} else {
 			if (isset($attributes['add_date'])) {
 				if ((int)$attributes['add_date'] > self::THOUSAND_YEARS) {
-					// Google exports dates in miliseconds. This way we only lose the first year of UNIX Epoch.
+					// Google exports dates in milliseconds. This way we only lose the first year of UNIX Epoch.
 					// This is invalid once we hit 2970. So, quite a long time.
 					$attributes['add_date'] = ((int)($attributes['add_date']) / 1000);
 				} else {
@@ -276,7 +276,7 @@ class BookmarksParser {
 			if (isset($attributes['last_modified'])) {
 				$attributes['last_modified'] = $attributes['last_modified'] instanceof DateTime ? $attributes['last_modified']->getTimestamp() : (int)$attributes['last_modified'];
 				if ((int)$attributes['last_modified'] > self::THOUSAND_YEARS) {
-					// Google exports dates in miliseconds. This way we only lose the first year of UNIX Epoch.
+					// Google exports dates in milliseconds. This way we only lose the first year of UNIX Epoch.
 					// This is invalid once we hit 2970. So, quite a long time.
 					$attributes['last_modified'] = ((int)($attributes['last_modified']) / 1000);
 				} else {

--- a/lib/Service/FaviconPreviewer.php
+++ b/lib/Service/FaviconPreviewer.php
@@ -138,7 +138,7 @@ class FaviconPreviewer implements IBookmarkPreviewer {
 		$body = $response->getBody();
 		$contentType = $response->getHeader('Content-Type');
 
-		// Some HTPP Error occured :/
+		// Some HTTP Error occurred :/
 		if ($response->getStatusCode() !== 200) {
 			return null;
 		}

--- a/lib/Service/Previewers/DefaultBookmarkPreviewer.php
+++ b/lib/Service/Previewers/DefaultBookmarkPreviewer.php
@@ -80,7 +80,7 @@ class DefaultBookmarkPreviewer implements IBookmarkPreviewer {
 		$body = $response->getBody();
 		$contentType = $response->getHeader('Content-Type');
 
-		// Some HTPP Error occured :/
+		// Some HTTP Error occurred :/
 		if ($response->getStatusCode() !== 200) {
 			return null;
 		}

--- a/lib/Service/Previewers/GenericUrlBookmarkPreviewer.php
+++ b/lib/Service/Previewers/GenericUrlBookmarkPreviewer.php
@@ -90,7 +90,7 @@ class GenericUrlBookmarkPreviewer implements IBookmarkPreviewer {
 			return null;
 		}
 
-		// Some HTPP Error occured :/
+		// Some HTTP Error occurred :/
 		if ($response->getStatusCode() !== 200) {
 			return null;
 		}

--- a/lib/Service/Previewers/ScreeenlyBookmarkPreviewer.php
+++ b/lib/Service/Previewers/ScreeenlyBookmarkPreviewer.php
@@ -96,7 +96,7 @@ class ScreeenlyBookmarkPreviewer implements IBookmarkPreviewer {
 			return null;
 		}
 
-		// Some HTPP Error occured :/
+		// Some HTTP Error occurred :/
 		if ($response->getStatusCode() !== 200) {
 			return null;
 		}

--- a/lib/Service/Previewers/ScreenshotMachineBookmarkPreviewer.php
+++ b/lib/Service/Previewers/ScreenshotMachineBookmarkPreviewer.php
@@ -83,7 +83,7 @@ class ScreenshotMachineBookmarkPreviewer implements IBookmarkPreviewer {
 					'timeout' => self::HTTP_TIMEOUT,
 				]
 			);
-			// Some HTPP Error occured :/
+			// Some HTTP Error occurred :/
 			if ($response->getStatusCode() !== 200) {
 				return null;
 			}

--- a/lib/Service/Previewers/WebshotBookmarkPreviewer.php
+++ b/lib/Service/Previewers/WebshotBookmarkPreviewer.php
@@ -93,7 +93,7 @@ class WebshotBookmarkPreviewer implements IBookmarkPreviewer {
 			],
 				'timeout' => self::HTTP_TIMEOUT,
 			]);
-			// Some HTPP Error occured :/
+			// Some HTTP Error occurred :/
 			if ($response->getStatusCode() !== 200) {
 				return null;
 			}
@@ -101,7 +101,7 @@ class WebshotBookmarkPreviewer implements IBookmarkPreviewer {
 
 			// get it
 			$response = $this->client->get($this->apiUrl . $data->id);
-			// Some HTPP Error occured :/
+			// Some HTTP Error occurred :/
 			if ($response->getStatusCode() !== 200) {
 				return null;
 			}


### PR DESCRIPTION
Fixed 5 spelling errors across 9 files:

- `miliseconds` → `milliseconds` (3x)
- `shoudl` → `should` (2x)
- `recurisve` → `recursive` (1x)
- `occured` → `occurred` (7x)
- `HTPP` → `HTTP` (7x)

Assisted-by: DeepSeek:V4-Pro